### PR TITLE
Use local thread pool for audio transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ openpyxl para cargar reglas desde archivos Excel
 
 dotenv para manejar tokens y credenciales
 
+ThreadPoolExecutor para procesar transcripciones de audio en segundo plano (sin necesidad de Redis)
+
 ✅ Estado actual
 La app ya está funcionando con:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,3 @@ gunicorn
 openpyxl
 mysql-connector-python
 vosk
-
-redis
-rq


### PR DESCRIPTION
## Summary
- Replace Redis/RQ queue with local `ThreadPoolExecutor` for audio transcription jobs
- Remove `redis` and `rq` from dependencies
- Document that audio transcription runs on a local thread and no longer requires Redis

## Testing
- `python -m py_compile services/job_queue.py`


------
https://chatgpt.com/codex/tasks/task_e_689bd7c3114c83238595524d919721ba