### PR TITLE
Add responsive viewport to HTML templates

### DIFF
--- a/templates/botones.html
+++ b/templates/botones.html
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Configuración de Botones</title>
     <style>
         body {

--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Configuración de Reglas</title>
     <style>
         body {

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Chat Tecnimedellín</title>
   <style>
     :root {

--- a/templates/login.html
+++ b/templates/login.html
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Iniciar sesión</title>
     <style>
         body {

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Reglas</title>
     <style>
         body {

--- a/templates/roles.html
+++ b/templates/roles.html
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Roles</title>
     <style>
         body {

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Tablero</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>


### PR DESCRIPTION
## Summary
- ensure all HTML templates include a viewport meta tag for proper scaling on mobile devices

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8213461c8323a5e4a7c291933937