### PR TITLE
Add media types aggregation for buttons

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -57,7 +57,8 @@ def index():
     c.execute(
         """
         SELECT b.id, b.mensaje, b.tipo,
-               GROUP_CONCAT(m.media_url SEPARATOR '||') AS media_urls
+               GROUP_CONCAT(m.media_url SEPARATOR '||') AS media_urls,
+               GROUP_CONCAT(m.media_tipo SEPARATOR '||') AS media_tipos
           FROM botones b
           LEFT JOIN boton_medias m ON b.id = m.boton_id
          GROUP BY b.id

--- a/routes/configuracion.py
+++ b/routes/configuracion.py
@@ -316,7 +316,8 @@ def botones():
         c.execute(
             """
             SELECT b.id, b.mensaje, b.tipo,
-                   GROUP_CONCAT(m.media_url SEPARATOR '||') AS media_urls
+                   GROUP_CONCAT(m.media_url SEPARATOR '||') AS media_urls,
+                   GROUP_CONCAT(m.media_tipo SEPARATOR '||') AS media_tipos
               FROM botones b
               LEFT JOIN boton_medias m ON b.id = m.boton_id
              GROUP BY b.id
@@ -350,7 +351,8 @@ def get_botones():
         c.execute(
             """
             SELECT b.id, b.mensaje, b.tipo,
-                   GROUP_CONCAT(m.media_url SEPARATOR '||') AS media_urls
+                   GROUP_CONCAT(m.media_url SEPARATOR '||') AS media_urls,
+                   GROUP_CONCAT(m.media_tipo SEPARATOR '||') AS media_tipos
               FROM botones b
               LEFT JOIN boton_medias m ON b.id = m.boton_id
              GROUP BY b.id
@@ -363,7 +365,8 @@ def get_botones():
                 'id': r[0],
                 'mensaje': r[1],
                 'tipo': r[2],
-                'media_urls': r[3].split('||') if r[3] else []
+                'media_urls': r[3].split('||') if r[3] else [],
+                'media_tipos': r[4].split('||') if r[4] else []
             }
             for r in rows
         ])


### PR DESCRIPTION
## Summary
- Include media type aggregation in button queries
- Expose `media_tipos` in `/get_botones` response

## Testing
- `python -m py_compile routes/configuracion.py routes/chat_routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f8869cfc8323a9576c165be8be54