### PR TITLE
refactor chat interface into typed subcomponents

### DIFF
--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+interface MessageInputProps {
+  text: string;
+  onTextChange: (value: string) => void;
+  onSendText: () => void;
+  onSendMedia: (
+    e: React.ChangeEvent<HTMLInputElement>,
+    tipo: 'image' | 'audio' | 'video'
+  ) => void;
+}
+
+const MessageInput: React.FC<MessageInputProps> = ({
+  text,
+  onTextChange,
+  onSendText,
+  onSendMedia,
+}) => (
+  <div className="flex items-center gap-2 p-2 border-t">
+    <input type="file" accept="image/*" onChange={e => onSendMedia(e, 'image')} />
+    <input type="file" accept="audio/*" onChange={e => onSendMedia(e, 'audio')} />
+    <input type="file" accept="video/*" onChange={e => onSendMedia(e, 'video')} />
+    <input
+      value={text}
+      onChange={e => onTextChange(e.target.value)}
+      placeholder="Mensaje"
+      className="flex-1 p-1 border rounded"
+    />
+    <button onClick={onSendText} className="px-3 py-1 rounded bg-primary text-white shadow-elegant">
+      Enviar
+    </button>
+  </div>
+);
+
+export default MessageInput;

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Message } from '../types/chat';
+
+const MediaContent: React.FC<{ tipo: string; url: string }> = ({ tipo, url }) => {
+  const [error, setError] = useState(false);
+  if (error) {
+    return <div className="media-error">No se pudo cargar el archivo</div>;
+  }
+  if (tipo && tipo.includes('image')) {
+    return <img src={url} className="media-image" onError={() => setError(true)} alt="imagen" />;
+  }
+  if (tipo && tipo.includes('audio')) {
+    return <audio controls src={url} className="media-audio" onError={() => setError(true)} />;
+  }
+  if (tipo && tipo.includes('video')) {
+    return <video controls src={url} className="media-video" onError={() => setError(true)} />;
+  }
+  return (
+    <a href={url} target="_blank" rel="noopener noreferrer" className="media-link">
+      {url}
+    </a>
+  );
+};
+
+interface MessageListProps {
+  messages: Message[];
+}
+
+const MessageList: React.FC<MessageListProps> = ({ messages }) => {
+  const endRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  return (
+    <div className="flex-1 p-2 overflow-y-auto">
+      {messages.map((m, i) => {
+        const bubbleClass = [
+          'max-w-[70%] p-2 my-1 rounded-lg break-words',
+          (m.tipo === 'bot' || m.tipo === 'asesor' || m.tipo?.startsWith('bot_') || m.tipo?.startsWith('asesor_'))
+            ? 'bg-primary self-end text-white'
+            : 'bg-white border self-start'
+        ].join(' ');
+        return (
+          <div key={m.waId ?? i} className={bubbleClass}>
+            {m.text && <span>{m.text}</span>}
+            {m.mediaUrl && <MediaContent tipo={m.tipo} url={m.mediaUrl} />}
+          </div>
+        );
+      })}
+      <div ref={endRef} />
+    </div>
+  );
+};
+
+export default MessageList;

--- a/frontend/src/components/QuickButtons.tsx
+++ b/frontend/src/components/QuickButtons.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { QuickButton } from '../types/chat';
+
+interface QuickButtonsProps {
+  buttons: QuickButton[];
+  onSend: (button: QuickButton) => void;
+}
+
+const QuickButtons: React.FC<QuickButtonsProps> = ({ buttons, onSend }) => (
+  <div className="flex gap-2 p-2 border-t bg-gray-50">
+    {buttons.map((b, i) => (
+      <button
+        key={i}
+        className="px-3 py-1 border rounded bg-white shadow-elegant"
+        onClick={() => onSend(b)}
+      >
+        {b.nombre || i + 1}
+      </button>
+    ))}
+  </div>
+);
+
+export default QuickButtons;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Contact } from '../types/chat';
+
+interface SidebarProps {
+  contacts: Contact[];
+  currentChat: string | null;
+  onSelect: (numero: string) => void;
+}
+
+const Sidebar: React.FC<SidebarProps> = ({ contacts, currentChat, onSelect }) => (
+  <aside className="flex flex-col w-64 bg-secondary shadow-elegant overflow-y-auto">
+    <ul>
+      {contacts.map(c => (
+        <li
+          key={c.numero}
+          className={`p-2 cursor-pointer ${currentChat === c.numero ? 'bg-primary text-white' : ''}`}
+          onClick={() => onSelect(c.numero)}
+        >
+          {c.alias ? `${c.alias} (${c.numero})` : c.numero}
+        </li>
+      ))}
+    </ul>
+  </aside>
+);
+
+export default Sidebar;

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -1,0 +1,18 @@
+export interface Contact {
+  numero: string;
+  alias?: string;
+}
+
+export interface Message {
+  text: string;
+  tipo: string;
+  mediaUrl?: string;
+  waId?: string;
+}
+
+export interface QuickButton {
+  nombre?: string;
+  mensaje: string;
+  tipo: string;
+  media_urls?: string[];
+}


### PR DESCRIPTION
## Summary
- add shared chat interfaces for contacts, messages and quick reply buttons
- split chat UI into Sidebar, MessageList, MessageInput and QuickButtons components
- refactor ChatInterface to use typed state and subcomponents

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a675cfad8083239fe3093d9d169e0a