### PR TITLE
feat: add sidebar search with avatars and role badges

### DIFF
--- a/frontend/src/components/Avatar.tsx
+++ b/frontend/src/components/Avatar.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface AvatarProps {
+  name: string;
+  photoUrl?: string;
+}
+
+const Avatar: React.FC<AvatarProps> = ({ name, photoUrl }) => {
+  if (photoUrl) {
+    return <img src={photoUrl} alt={name} className="w-10 h-10 rounded-full" />;
+  }
+  const initials = name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+  return (
+    <div className="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary font-semibold">
+      {initials}
+    </div>
+  );
+};
+
+export default Avatar;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Contact } from '../types/chat';
+import Avatar from './Avatar';
 
 interface SidebarProps {
   contacts: Contact[];
@@ -7,20 +8,52 @@ interface SidebarProps {
   onSelect: (numero: string) => void;
 }
 
-const Sidebar: React.FC<SidebarProps> = ({ contacts, currentChat, onSelect }) => (
-  <aside className="flex flex-col w-64 bg-secondary shadow-elegant overflow-y-auto">
-    <ul>
-      {contacts.map(c => (
-        <li
-          key={c.numero}
-          className={`p-2 cursor-pointer ${currentChat === c.numero ? 'bg-primary text-white' : ''}`}
-          onClick={() => onSelect(c.numero)}
-        >
-          {c.alias ? `${c.alias} (${c.numero})` : c.numero}
-        </li>
-      ))}
-    </ul>
-  </aside>
-);
+const roleStyles: Record<'usuario' | 'bot' | 'admin', string> = {
+  usuario: 'bg-blue-100 text-blue-800',
+  bot: 'bg-green-100 text-green-800',
+  admin: 'bg-red-100 text-red-800',
+};
+
+const Sidebar: React.FC<SidebarProps> = ({ contacts, currentChat, onSelect }) => {
+  const [query, setQuery] = useState('');
+  const filtered = contacts.filter(c => {
+    const name = c.alias || c.numero;
+    return name.toLowerCase().includes(query.toLowerCase());
+  });
+
+  return (
+    <aside className="flex flex-col w-64 bg-secondary text-white shadow-elegant">
+      <div className="p-2">
+        <input
+          type="text"
+          placeholder="Buscar..."
+          className="w-full p-2 rounded text-black"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+        />
+      </div>
+      <ul className="flex-1 overflow-y-auto">
+        {filtered.map(c => (
+          <li
+            key={c.numero}
+            className={`flex items-center gap-2 p-2 cursor-pointer hover:bg-primary/10 ${
+              currentChat === c.numero ? 'bg-primary/10' : ''
+            }`}
+            onClick={() => onSelect(c.numero)}
+          >
+            <Avatar name={c.alias || c.numero} photoUrl={c.avatarUrl} />
+            <div className="flex flex-col">
+              <span className="text-sm font-medium">{c.alias || c.numero}</span>
+              {c.alias && <span className="text-xs text-gray-200">{c.numero}</span>}
+            </div>
+            {c.role && (
+              <span className={`badge-role ml-auto ${roleStyles[c.role]}`}>{c.role}</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+};
 
 export default Sidebar;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -128,3 +128,9 @@ body {
   border-radius: 4px;
   cursor: pointer;
 }
+
+@layer components {
+  .badge-role {
+    @apply text-xs font-semibold px-2 py-0.5 rounded;
+  }
+}

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -1,6 +1,8 @@
 export interface Contact {
   numero: string;
   alias?: string;
+  role?: 'usuario' | 'bot' | 'admin';
+  avatarUrl?: string;
 }
 
 export interface Message {


### PR DESCRIPTION
## Summary
- add reusable Avatar component for contact initials or photos
- enhance Sidebar with search, role badges, and hover styling
- extend Contact type with optional role and avatar fields
- add Tailwind `badge-role` utility

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: No files matching the pattern ".")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a676caa2808323a10559a816a064a0