### PR TITLE
Add primary button styling with ripple effect

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -313,6 +313,51 @@
     form button:hover {
       background: var(--accent-hover);
     }
+
+    /* Reusable primary button with hover transition and ripple effect */
+    .btn-primary {
+      background: var(--accent);
+      color: var(--text-light);
+      border: none;
+      padding: 10px 20px;
+      border-radius: 4px;
+      cursor: pointer;
+      position: relative;
+      overflow: hidden;
+      transition: transform 0.2s, background 0.3s;
+    }
+    .btn-primary:hover {
+      transform: scale(1.05);
+      background: var(--accent-hover);
+    }
+    .btn-primary::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 0;
+      height: 0;
+      background: rgba(255,255,255,0.4);
+      border-radius: 50%;
+      transform: translate(-50%, -50%);
+      pointer-events: none;
+    }
+    .btn-primary:active::after {
+      animation: ripple 0.6s ease-out;
+    }
+    @keyframes ripple {
+      from {
+        opacity: 0.4;
+        width: 0;
+        height: 0;
+      }
+      to {
+        opacity: 0;
+        width: 200%;
+        height: 200%;
+      }
+    }
+
     table {
       width: 100%;
       border-collapse: collapse;

--- a/templates/botones.html
+++ b/templates/botones.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="top-right">
     <a href="{{ url_for('chat.index') }}">
-        <button class="back-btn">Volver al inicio</button>
+        <button class="back-btn btn-primary">Volver al inicio</button>
     </a>
 </div>
 
@@ -32,13 +32,13 @@
     <label for="media_url" id="label_media_url" style="display:none;">URLs de archivos (separadas por comas o saltos de línea):</label>
     <textarea id="media_url" name="media_url" style="display:none;" placeholder="URL1, URL2&#10;URL3"></textarea>
 
-    <button type="submit">Agregar botón</button>
+    <button type="submit" class="btn-primary">Agregar botón</button>
 </form>
 
 <form method="POST" enctype="multipart/form-data">
     <label for="archivo">Importar botones desde Excel:</label>
     <input type="file" name="archivo" accept=".xlsx" required>
-    <button type="submit">Importar</button>
+    <button type="submit" class="btn-primary">Importar</button>
 </form>
 
 <h3>Botones actuales</h3>
@@ -52,7 +52,7 @@
         <td style="word-break: break-all;">{{ b[4]|default('')|replace('||', '<br>')|safe }}</td>
         <td>
             <form method="POST" action="{{ url_for('configuracion.eliminar_boton', boton_id=b[0]) }}">
-                <button class="delete-btn" type="submit">Eliminar</button>
+                <button class="delete-btn btn-primary" type="submit">Eliminar</button>
             </form>
         </td>
     </tr>

--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="top-right">
     <a href="{{ url_for('chat.index') }}">
-        <button class="back-btn">Volver al inicio</button>
+        <button class="back-btn btn-primary">Volver al inicio</button>
     </a>
 </div>
 
@@ -54,13 +54,13 @@
     <label for="opciones">Opciones (solo para listas, formato JSON):</label><br>
     <textarea name="opciones" rows="6" cols="60" placeholder='[{"title":"Rápido","rows":[{"id":"express","title":"Express","description":"1 día"}]}]'></textarea>
 
-    <button type="submit">Guardar regla</button>
+    <button type="submit" class="btn-primary">Guardar regla</button>
 </form>
 
 <form method="POST" enctype="multipart/form-data">
     <h3>Importar reglas desde archivo Excel (.xlsx)</h3>
     <input type="file" name="archivo" accept=".xlsx" required>
-    <button type="submit">Importar reglas</button>
+    <button type="submit" class="btn-primary">Importar reglas</button>
 </form>
 
 <h3>Reglas existentes</h3>
@@ -96,7 +96,7 @@
         <td>{{ regla[11] or '-' }}</td>
         <td>
             <form method="POST" action="{{ url_for('configuracion.eliminar_regla', regla_id=regla[0]) }}">
-                <button class="delete-btn" type="submit">Eliminar</button>
+                <button class="delete-btn btn-primary" type="submit">Eliminar</button>
             </form>
         </td>
     </tr>

--- a/templates/roles.html
+++ b/templates/roles.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="top-right">
     <a href="{{ url_for('chat.index') }}">
-        <button class="back-btn">Volver al inicio</button>
+        <button class="back-btn btn-primary">Volver al inicio</button>
     </a>
 </div>
 
@@ -13,7 +13,7 @@
     <h3>Crear rol</h3>
     <input type="text" name="name" placeholder="Nombre" required>
     <input type="text" name="keyword" placeholder="Palabra clave">
-    <button type="submit">Crear</button>
+    <button type="submit" class="btn-primary">Crear</button>
 </form>
 
 <table>
@@ -30,12 +30,12 @@
         <td>{{ ', '.join(asignaciones.get(rol[0], [])) }}</td>
         <td>
             <form action="{{ url_for('roles.eliminar_rol', rol_id=rol[0]) }}" method="post" style="display:inline; background:none; box-shadow:none; padding:0; margin:0;">
-                <button type="submit" class="delete-btn">Eliminar</button>
+                <button type="submit" class="delete-btn btn-primary">Eliminar</button>
             </form>
             <form action="{{ url_for('roles.editar_rol', rol_id=rol[0]) }}" method="post" style="display:inline; background:none; box-shadow:none; padding:0; margin:0;">
                 <input type="text" name="name" value="{{ rol[1] }}" required style="width:auto; padding:4px; margin:0 4px 0 0;">
                 <input type="text" name="keyword" value="{{ rol[2] }}" style="width:auto; padding:4px; margin:0 4px 0 0;">
-                <button type="submit">Actualizar</button>
+                <button type="submit" class="btn-primary">Actualizar</button>
             </form>
         </td>
     </tr>
@@ -54,7 +54,7 @@
         <option value="{{ rol[0] }}">{{ rol[1] }}</option>
     {% endfor %}
     </select>
-    <button type="submit">Asignar</button>
+    <button type="submit" class="btn-primary">Asignar</button>
 </form>
 
 <form action="{{ url_for('roles.quitar_rol') }}" method="post">
@@ -69,6 +69,6 @@
         <option value="{{ rol[0] }}">{{ rol[1] }}</option>
     {% endfor %}
     </select>
-    <button type="submit">Quitar</button>
+    <button type="submit" class="btn-primary">Quitar</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add reusable `.btn-primary` class with hover transitions and ripple animation
- Apply new button styling to configuration, roles, and quick buttons pages

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a8cd55540c8323bb40d95b9c58a8e9