### PR TITLE
Add Streamlit dashboard link and route

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from routes.configuracion import config_bp
 from routes.roles_routes import roles_bp
 from routes.webhook import webhook_bp
 from routes.tablero_routes import tablero_bp
+from routes.streamlit_routes import streamlit_bp
 
 load_dotenv()
 
@@ -26,6 +27,7 @@ def create_app():
     app.register_blueprint(roles_bp)
     app.register_blueprint(webhook_bp)
     app.register_blueprint(tablero_bp)
+    app.register_blueprint(streamlit_bp)
 
     # Inicializa BD solo si se pide explícitamente y dentro del app_context
     if os.getenv("INIT_DB_ON_START", "0") == "1":

--- a/routes/streamlit_routes.py
+++ b/routes/streamlit_routes.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, render_template_string
+
+streamlit_bp = Blueprint('streamlit', __name__, url_prefix='/streamlit')
+
+@streamlit_bp.route('/')
+def dashboard():
+    """Render an iframe embedding the Streamlit dashboard."""
+    iframe_html = (
+        "<iframe src='http://localhost:8501' style='width:100%; height:100vh; border:none;'></iframe>"
+    )
+    return render_template_string(iframe_html)

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,7 @@
         <a href="{{ url_for('roles.roles') }}">Roles</a>
         {% endif %}
         <a href="{{ url_for('tablero.tablero') }}">Tablero</a>
+        <a href="{{ url_for('streamlit.dashboard') }}">Streamlit</a>
         <a href="{{ url_for('auth.logout') }}">Cerrar sesión</a>
       </div>
       <input id="buscador" type="text" placeholder="Buscar número…">


### PR DESCRIPTION
## Summary
- Link Streamlit dashboard from settings menu
- Add Streamlit blueprint serving Streamlit app in an iframe
- Register new blueprint in application factory

## Testing
- `python -m py_compile app.py routes/streamlit_routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae8baaf4048323b6394edd5afecad7