### PR TITLE
chore: build frontend in multi-stage Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
-# ---- Base image ----
+########## Frontend build stage ##########
+FROM node:18 AS build-frontend
+
+WORKDIR /app/frontend
+COPY frontend/ .
+RUN npm install && npm run build
+
+########## Final image ##########
 FROM python:3.11-slim
 
-ENV PYTHONDONTWRITEBYTECODE=1     PYTHONUNBUFFERED=1     PORT=8080
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=5000
 
 WORKDIR /app
 
@@ -13,12 +22,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python deps first (better layer caching)
-# If you don't have requirements.txt, you can remove the next two lines.
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt || true
 
-# Copy the app
+# Copy the app source
 COPY . /app
+
+# Copy built frontend assets
+COPY --from=build-frontend /app/frontend/dist /app/static/
 
 # Create non-root user and fix ownership so app can write to /app/*
 RUN useradd -m appuser && \
@@ -30,4 +41,4 @@ USER appuser
 EXPOSE ${PORT}
 
 # Run the Flask app with Gunicorn
-CMD bash -lc 'gunicorn -w 2 -b 0.0.0.0:${PORT:-8080} app:app'
+CMD bash -lc 'gunicorn -w 2 -b 0.0.0.0:${PORT:-5000} app:app'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,3 @@ services:
       bash -lc '(command -v gunicorn >/dev/null &&
                  exec gunicorn -w 2 -b 0.0.0.0:${PORT:-5000} app:app ||
                  exec python app.py)'
-  frontend:
-    build: ./frontend
-    ports:
-      - "3000:5173"
-    volumes:
-      - ./frontend:/app
-    command: npm run dev -- --host


### PR DESCRIPTION
## Summary
- build frontend in dedicated Node stage and copy build artifacts into Python image
- expose only Flask port and drop dev frontend service from docker-compose

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af295b999c83239cfd1dc33757ab56