### PR TITLE
Add 'iniciar' global command

### DIFF
--- a/services/global_commands.py
+++ b/services/global_commands.py
@@ -54,7 +54,7 @@ def reiniciar_handler(numero, text):
 
 
 # Registrar comandos por defecto
-for cmd in ['reiniciar', 'volver al inicio', 'inicio', 'menú', 'menu', 'ayuda']:
+for cmd in ['reiniciar', 'volver al inicio', 'inicio', 'iniciar', 'menú', 'menu', 'ayuda']:
     GLOBAL_COMMANDS[normalize_text(cmd)] = reiniciar_handler
 
 


### PR DESCRIPTION
## Summary
- recognize 'iniciar' as a default global command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b07e461c5c8323a37cd385d719b203