### PR TITLE
Procesar primer mensaje en webhook

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -200,13 +200,15 @@ def handle_text_message(numero: str, texto: str):
     user_last_activity[numero] = now
     if not user_steps.get(numero):
         set_user_step(numero, Config.INITIAL_STEP)
+        process_step_chain(numero, 'iniciar')
+        return
 
     text_norm = normalize_text(texto or "")
 
     if handle_global_command(numero, texto):
         return
 
-    process_step_chain(numero, text_norm or 'iniciar')
+    process_step_chain(numero, text_norm)
 
 
 def process_buffered_messages(numero):


### PR DESCRIPTION
## Summary
- Ejecutar `process_step_chain` con `iniciar` al primer mensaje de un número
- Usar siempre el texto normalizado en mensajes siguientes

## Testing
- `python -m py_compile routes/webhook.py`
- `pytest 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b1abec28a48323b6bfa4ee826a351a