### PR TITLE
Amplía tamaño de gráficos en tablero

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -46,6 +46,7 @@
   margin-top: 20px;
   width: 100%;
   height: auto;
+  min-height: 300px;
 }
 
 @media (min-width: 768px) {

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -3,7 +3,8 @@ document.addEventListener('DOMContentLoaded', () => {
   let chartTotales, chartDiario, chartHora, chartTablero, chartTopNumeros, chartPalabras, chartRoles, chartTipos, chartTiposDiarios;
   const commonOptions = {
     animation: { duration: 1000 },
-    interaction: { mode: 'nearest', intersect: false }
+    interaction: { mode: 'nearest', intersect: false },
+    maintainAspectRatio: false
   };
   const startInput = document.getElementById('fechaInicio');
   const endInput = document.getElementById('fechaFin');

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -53,25 +53,25 @@
                 <h3><span class="icon">📊</span> Totales de mensajes</h3>
                 <p>Enviados: <span id="totalEnviados">0</span></p>
                 <p>Recibidos: <span id="totalRecibidos">0</span></p>
-                <canvas id="graficoTotales" height="120"></canvas>
+                <canvas id="graficoTotales"></canvas>
             </div>
         </section>
         <section class="reports graficas" id="reportes">
             <div class="card">
                 <h4>Mensajes por Día</h4>
-                <canvas id="graficoDiario" height="120"></canvas>
+                <canvas id="graficoDiario"></canvas>
             </div>
             <div class="card">
                 <h4>Mensajes por Hora</h4>
-                <canvas id="graficoHora" height="120"></canvas>
+                <canvas id="graficoHora"></canvas>
             </div>
             <div class="card">
                 <h4>Mensajes por Usuario</h4>
-                <canvas id="grafico" height="120"></canvas>
+                <canvas id="grafico"></canvas>
             </div>
             <div class="card">
                 <h4>Top Números</h4>
-                <canvas id="graficoTopNumeros" height="120"></canvas>
+                <canvas id="graficoTopNumeros"></canvas>
                 <table id="tabla_top_numeros">
                     <thead>
                         <tr>
@@ -84,7 +84,7 @@
             </div>
             <div class="card">
                 <h4>Palabras Más Usadas</h4>
-                <canvas id="grafico_palabras" height="120"></canvas>
+                <canvas id="grafico_palabras"></canvas>
                 <table id="tabla_palabras">
                     <thead>
                         <tr>
@@ -97,7 +97,7 @@
             </div>
             <div class="card">
                 <h4>Roles</h4>
-                <canvas id="grafico_roles" height="120"></canvas>
+                <canvas id="grafico_roles"></canvas>
                 <table id="tabla_roles">
                     <thead>
                         <tr>
@@ -110,11 +110,11 @@
             </div>
             <div class="card">
                 <h4>Tipos de Mensaje</h4>
-                <canvas id="graficoTipos" height="120"></canvas>
+                <canvas id="graficoTipos"></canvas>
             </div>
             <div class="card">
                 <h4>Tipos por Día</h4>
-                <canvas id="graficoTiposDiarios" height="120"></canvas>
+                <canvas id="graficoTiposDiarios"></canvas>
             </div>
         </section>
     </div>


### PR DESCRIPTION
## Summary
- Remove fixed height attributes from dashboard canvases
- Ensure card canvases have a minimum height via CSS
- Disable Chart.js aspect ratio preservation for responsive charts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b31d5dad9c832387b7c079196329fc