### PR TITLE
Center dashboard content and enforce chart aspect ratio

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -3,6 +3,7 @@
   gap: 2rem;
   margin: 2rem;
   grid-template-columns: 1fr;
+  justify-items: center;
 }
 
 .totales {
@@ -24,12 +25,19 @@
   margin-bottom: 20px;
 }
 
+.reports {
+  justify-items: center;
+}
+
 .card {
   background: #fff;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.07);
   padding: 1.5rem;
   margin-bottom: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .card h3, .card h4 {
@@ -43,10 +51,11 @@
 }
 
 .card canvas {
-  margin-top: 20px;
   width: 100%;
-  height: auto;
-  min-height: 300px;
+  height: 400px;
+  max-width: 90%;
+  display: block;
+  margin: 0 auto;
 }
 
 @media (min-width: 768px) {
@@ -59,7 +68,7 @@
   }
 
   .reports {
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
   }
 }
 

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const commonOptions = {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false },
-    maintainAspectRatio: false
+    maintainAspectRatio: true
   };
   const startInput = document.getElementById('fechaInicio');
   const endInput = document.getElementById('fechaFin');


### PR DESCRIPTION
## Summary
- center dashboard cards and reports for improved layout
- constrain chart canvas dimensions and ensure Chart.js maintains aspect ratio

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b32048d724832392ca8f9f7abd2ed8