### PR TITLE
Estiliza fila ancha del tablero

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -53,22 +53,19 @@
 }
 
 .wide-row {
+  grid-column: 1 / -1;  /* ocupar todo el ancho de la cuadrícula */
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(2, 1fr);
   gap: 20px;
 }
 
-.large-chart {
-  grid-column: span 1;
-}
-
-.large-chart canvas {
-  height: 400px;
-}
-
+/* ajustar la altura para que la fila no se vea tan larga */
 .wide-row .card canvas {
-  width: 100%;
-  height: 400px;
+  height: 250px; /* o el valor que se prefiera */
+}
+
+@media (max-width: 768px) {
+  .wide-row { grid-template-columns: 1fr; }  /* apilar en pantallas pequeñas */
 }
 
 @media (min-width: 768px) {

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -64,7 +64,7 @@
                 <canvas id="graficoTotales"></canvas>
             </div>
             <div class="wide-row">
-                <div class="card large-chart">
+                <div class="card">
                     <h4>Mensajes por Día</h4>
                     <canvas id="graficoDiario"></canvas>
                     <table id="tabla_dia_semana">


### PR DESCRIPTION
## Summary
- Amplía `.wide-row` para que ocupe todo el ancho y se adapte en móviles
- Ajusta altura de los gráficos en la fila ancha para una vista más compacta
- Limpia el HTML del tablero eliminando clase `large-chart` innecesaria

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5b89227648323824b947ee7ffa5ed