### PR TITLE
Disable chart aspect ratio maintenance

### DIFF
--- a/static/tablero.js
+++ b/static/tablero.js
@@ -12,7 +12,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const commonOptions = {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false },
-    maintainAspectRatio: true
+    maintainAspectRatio: false
   };
   const startInput = document.getElementById('fechaInicio');
   const endInput = document.getElementById('fechaFin');
@@ -212,7 +212,6 @@ document.addEventListener('DOMContentLoaded', () => {
           },
           options: {
             ...commonOptions,
-            maintainAspectRatio: false,
             scales: {
               y: { beginAtZero: true }
             }
@@ -281,7 +280,6 @@ document.addEventListener('DOMContentLoaded', () => {
           },
           options: {
             ...commonOptions,
-            maintainAspectRatio: false,
             scales: {
               y: { beginAtZero: true }
             }


### PR DESCRIPTION
## Summary
- globally disable Chart.js aspect ratio maintenance in `tablero.js`
- rely on shared options across all charts without per-chart overrides

## Testing
- `pytest` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bda19534832399c1188fa9e89e8b