### PR TITLE
Define explicit canvas dimensions

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -46,8 +46,9 @@
 }
 
 .card canvas {
-  width: 100%;
-  height: 150px;
+  width: 280px;
+  height: 180px;
+  max-width: 100%;
   display: block;
   margin: 0 auto;
 }


### PR DESCRIPTION
## Summary
- set explicit canvas width and height within card for dashboard

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5bef6749c8323a5f7ef4b7a040f2d