### PR TITLE
Fix dashboard canvas resizing issues

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -46,9 +46,8 @@
 }
 
 .card canvas {
-  width: 280px;
-  height: 180px;
-  max-width: 100%;
+  width: 280px !important;
+  height: 180px !important;
   display: block;
   margin: 0 auto;
 }

--- a/static/tablero.js
+++ b/static/tablero.js
@@ -12,7 +12,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const commonOptions = {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false },
-    maintainAspectRatio: false
+    maintainAspectRatio: false,
+    responsive: false
   };
   const startInput = document.getElementById('fechaInicio');
   const endInput = document.getElementById('fechaFin');

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -61,12 +61,12 @@
         <section class="reports" id="reportes">
             <div class="card">
                 <h3><span class="icon">📊</span> Totales de mensajes</h3>
-                <canvas id="graficoTotales"></canvas>
+                <canvas id="graficoTotales" width="280" height="180"></canvas>
             </div>
             <div class="wide-row">
                 <div class="card">
                     <h4>Mensajes por Día</h4>
-                    <canvas id="graficoDiario"></canvas>
+                    <canvas id="graficoDiario" width="280" height="180"></canvas>
                     <table id="tabla_dia_semana">
                         <thead><tr><th>Día</th><th>Mensajes</th></tr></thead>
                         <tbody></tbody>
@@ -74,16 +74,16 @@
                 </div>
                 <div class="card">
                     <h4>Mensajes por Hora</h4>
-                    <canvas id="graficoHora"></canvas>
+                    <canvas id="graficoHora" width="280" height="180"></canvas>
                 </div>
             </div>
             <div class="card">
                 <h4>Mensajes por Usuario</h4>
-                <canvas id="grafico"></canvas>
+                <canvas id="grafico" width="280" height="180"></canvas>
             </div>
             <div class="card">
                 <h4>Top Números</h4>
-                <canvas id="graficoTopNumeros"></canvas>
+                <canvas id="graficoTopNumeros" width="280" height="180"></canvas>
                 <table id="tabla_top_numeros">
                     <thead>
                         <tr>
@@ -96,7 +96,7 @@
             </div>
             <div class="card">
                 <h4>Palabras Más Usadas</h4>
-                <canvas id="grafico_palabras"></canvas>
+                <canvas id="grafico_palabras" width="280" height="180"></canvas>
                 <table id="tabla_palabras">
                     <thead>
                         <tr>
@@ -109,7 +109,7 @@
             </div>
             <div class="card">
                 <h4>Roles</h4>
-                <canvas id="grafico_roles"></canvas>
+                <canvas id="grafico_roles" width="280" height="180"></canvas>
                 <table id="tabla_roles">
                     <thead>
                         <tr>
@@ -122,11 +122,11 @@
             </div>
             <div class="card">
                 <h4>Tipos de Mensaje</h4>
-                <canvas id="graficoTipos"></canvas>
+                <canvas id="graficoTipos" width="280" height="180"></canvas>
             </div>
             <div class="card">
                 <h4>Tipos por Día</h4>
-                <canvas id="graficoTiposDiarios"></canvas>
+                <canvas id="graficoTiposDiarios" width="280" height="180"></canvas>
             </div>
         </section>
     </div>


### PR DESCRIPTION
## Summary
- disable Chart.js responsive resizing to keep fixed dimensions
- add explicit width/height on all dashboard canvas elements
- enforce fixed canvas size in CSS

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b5c2545d5883239f1ade2b7a2f6e38