### PR TITLE
Display chart and table side by side for several reports

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -42,7 +42,8 @@
 
 .chart-card {
   width: 100%;
-  height: 360px;
+  height: auto;
+  min-height: 360px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -70,6 +71,17 @@
 
 .chart-card canvas {
   flex: 0 0 200px;   /* Gráfico fijo arriba */
+}
+
+.chart-table {
+  display: flex;
+  gap: 1rem;
+  align-items: stretch;
+}
+
+.chart-table canvas,
+.chart-table table {
+  flex: 1;
 }
 
 .wide-row {

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -83,42 +83,48 @@
             </div>
             <div class="card chart-card">
                 <h4>Top Números</h4>
-                <canvas id="graficoTopNumeros" width="400" height="300"></canvas>
-                <table id="tabla_top_numeros">
-                    <thead>
-                        <tr>
-                            <th>Número</th>
-                            <th>Mensajes</th>
-                        </tr>
-                    </thead>
-                    <tbody></tbody>
-                </table>
+                <div class="chart-table">
+                    <canvas id="graficoTopNumeros" width="400" height="300"></canvas>
+                    <table id="tabla_top_numeros">
+                        <thead>
+                            <tr>
+                                <th>Número</th>
+                                <th>Mensajes</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
             </div>
             <div class="card chart-card">
                 <h4>Palabras Más Usadas</h4>
-                <canvas id="grafico_palabras" width="400" height="300"></canvas>
-                <table id="tabla_palabras">
-                    <thead>
-                        <tr>
-                            <th>Palabra</th>
-                            <th>Frecuencia</th>
-                        </tr>
-                    </thead>
-                    <tbody></tbody>
-                </table>
+                <div class="chart-table">
+                    <canvas id="grafico_palabras" width="400" height="300"></canvas>
+                    <table id="tabla_palabras">
+                        <thead>
+                            <tr>
+                                <th>Palabra</th>
+                                <th>Frecuencia</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
             </div>
             <div class="card chart-card">
                 <h4>Roles</h4>
-                <canvas id="grafico_roles" width="400" height="300"></canvas>
-                <table id="tabla_roles">
-                    <thead>
-                        <tr>
-                            <th>Rol</th>
-                            <th>Mensajes</th>
-                        </tr>
-                    </thead>
-                    <tbody></tbody>
-                </table>
+                <div class="chart-table">
+                    <canvas id="grafico_roles" width="400" height="300"></canvas>
+                    <table id="tabla_roles">
+                        <thead>
+                            <tr>
+                                <th>Rol</th>
+                                <th>Mensajes</th>
+                            </tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
             </div>
             <div class="card chart-card">
                 <h4>Tipos de Mensaje</h4>


### PR DESCRIPTION
## Summary
- Group charts and tables inside `chart-table` containers for Top Números, Palabras Más Usadas and Roles
- Add flex-based `.chart-table` styling and adjust `.chart-card` height behavior

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5e8a91ce4832394661b1dc0e0d768