### PR TITLE
Add fixed table layout and apply to admin views

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -387,6 +387,14 @@
       width: 100%;
       border-collapse: collapse;
     }
+    .fixed-table {
+      width: 800px;
+      height: 400px;
+      overflow-x: auto;
+      overflow-y: auto;
+      word-break: break-word;
+      white-space: normal;
+    }
     th, td {
       padding: 10px;
       text-align: left;

--- a/static/tablero.css
+++ b/static/tablero.css
@@ -81,7 +81,7 @@
 }
 
 .chart-table canvas,
-.chart-table table {
+.chart-table table:not(.fixed-table) {
   flex: 1;
 }
 
@@ -147,8 +147,10 @@
 }
 
 table {
-  width: 100%;
   border-collapse: collapse;
+}
+table:not(.fixed-table) {
+  width: 100%;
 }
 
 th, td {
@@ -157,13 +159,13 @@ th, td {
   border-bottom: 1px solid #ddd;
 }
 
-.card table {
+.card table:not(.fixed-table) {
   max-height: 150px;
   overflow-y: auto;
   display: block;
 }
 
-.chart-card table {
+.chart-card table:not(.fixed-table) {
   flex: 1;
   width: 100%;
   overflow-y: auto;

--- a/templates/botones.html
+++ b/templates/botones.html
@@ -42,7 +42,7 @@
 </form>
 
 <h3>Botones actuales</h3>
-<table>
+<table class="fixed-table">
     <tr><th>ID</th><th>Nombre</th><th>Mensaje</th><th>URLs</th><th>Acción</th></tr>
     {% for b in botones %}
     <tr>

--- a/templates/configuracion.html
+++ b/templates/configuracion.html
@@ -75,7 +75,7 @@
 </form>
 
 <h3>Reglas existentes</h3>
-<table>
+<table class="fixed-table">
     <tr>
         <th>ID</th>
         <th>Paso</th>

--- a/templates/reglas.html
+++ b/templates/reglas.html
@@ -75,7 +75,7 @@
 </form>
 
 <h3>Reglas existentes</h3>
-<table>
+<table class="fixed-table">
     <tr>
         <th>ID</th>
         <th>Paso</th>

--- a/templates/roles.html
+++ b/templates/roles.html
@@ -16,7 +16,7 @@
     <button type="submit" class="btn-primary">Crear</button>
 </form>
 
-<table>
+<table class="fixed-table">
     <tr>
         <th>Nombre</th>
         <th>Palabra clave</th>

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -63,7 +63,7 @@
                 <div class="card chart-card">
                     <h4>Mensajes por Día</h4>
                     <canvas id="graficoDiario"></canvas>
-                    <table id="tabla_dia_semana">
+                    <table id="tabla_dia_semana" class="fixed-table">
                         <thead><tr><th>Día</th><th>Mensajes</th></tr></thead>
                         <tbody></tbody>
                     </table>
@@ -85,7 +85,7 @@
                 <h4>Top Números</h4>
                 <div class="chart-table">
                     <canvas id="graficoTopNumeros"></canvas>
-                    <table id="tabla_top_numeros">
+                    <table id="tabla_top_numeros" class="fixed-table">
                         <thead>
                             <tr>
                                 <th>Número</th>
@@ -100,7 +100,7 @@
                 <h4>Palabras Más Usadas</h4>
                 <div class="chart-table">
                     <canvas id="grafico_palabras"></canvas>
-                    <table id="tabla_palabras">
+                    <table id="tabla_palabras" class="fixed-table">
                         <thead>
                             <tr>
                                 <th>Palabra</th>
@@ -115,7 +115,7 @@
                 <h4>Roles</h4>
                 <div class="chart-table">
                     <canvas id="grafico_roles"></canvas>
-                    <table id="tabla_roles">
+                    <table id="tabla_roles" class="fixed-table">
                         <thead>
                             <tr>
                                 <th>Rol</th>


### PR DESCRIPTION
## Summary
- Define `.fixed-table` class with fixed dimensions and scrolling.
- Apply `.fixed-table` to tables across admin and dashboard templates.
- Scope existing dashboard table styles to exclude `.fixed-table` so sizes remain fixed.

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b5ee475d5c83239156d8d6963940b2