### PR TITLE
Fix chart table layout to prevent overflow

### DIFF
--- a/static/tablero.css
+++ b/static/tablero.css
@@ -102,7 +102,8 @@
 }
 
 .chart-table .fixed-table {
-  flex: 1 1 50%;
+  flex: 1;
+  min-width: 0;
 }
 
 .wide-row {


### PR DESCRIPTION
## Summary
- allow chart tables to flex alongside canvases by updating CSS

## Testing
- `pytest`
- `python - <<'PY'
import app
app.app.config['SECRET_KEY']='dev'
client = app.app.test_client()
with client.session_transaction() as sess:
    sess['user']='tester'
resp = client.get('/tablero')
print('status', resp.status_code)
print('Tabla palabras exists?', b'tabla_palabras' in resp.data)
print('Tabla roles exists?', b'tabla_roles' in resp.data)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b6632a361883238d7cb04529437d0e