### PR TITLE
Make fixed-table responsive

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -388,8 +388,9 @@
       border-collapse: collapse;
     }
     .fixed-table {
-      width: 800px;
-      height: 400px;
+      width: 100%;
+      max-width: 800px;
+      max-height: 400px;
       overflow-x: auto;
       overflow-y: auto;
       word-break: break-word;


### PR DESCRIPTION
## Summary
- make the `fixed-table` container width responsive with a max width of 800px
- constrain table height with a 400px max height while retaining scrollbars

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b6f6599a108323b31f4135f7c839b5