### PR TITLE
docs: aclarar procesamiento de listas en memoria

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Flujo automático basado en reglas configurables (con pasos, respuestas, tipo de
 
 Las reglas de un mismo paso se evalúan en orden ascendente por `id` (o columna de prioridad) para mantener un criterio consistente.
 
+El procesamiento de listas de pasos (`step1,step2`) se realiza únicamente en memoria mediante la función `advance_steps`.
+
 Envío de mensajes por parte del asesor desde la interfaz web
 
 Interfaz tipo WhatsApp Web con:

--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -125,7 +125,12 @@ def dispatch_rule(numero, regla):
 
 
 def advance_steps(numero: str, steps_str: str):
-    """Avanza múltiples pasos enviando las reglas comodín correspondientes."""
+    """Avanza múltiples pasos enviando las reglas comodín correspondientes.
+
+    El procesamiento de la lista de pasos ocurre únicamente en memoria; solo
+    se persiste el último paso mediante ``set_user_step``. No se almacena el
+    detalle de la lista en la base de datos.
+    """
     steps = [s.strip().lower() for s in (steps_str or '').split(',') if s.strip()]
     if not steps:
         return


### PR DESCRIPTION
## Summary
- Document that step lists are processed only in memory via `advance_steps`
- Note in README that list processing doesn't persist intermediate steps

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b70e88421883239d2af2cb8c29ecf4