### PR TITLE
Handle chat role assignment for chats

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -281,9 +281,11 @@ def assign_chat_role():
     if 'user' not in session:
         return jsonify({'error': 'No autorizado'}), 401
 
-    data   = request.get_json()
+    data = request.get_json()
     numero = data.get('numero')
-    role_kw = data.get('role')
+    # "role" es el campo enviado desde el frontend, pero aceptamos
+    # opcionalmente "role_kw" para mayor claridad al llamar la API.
+    role_kw = data.get('role') or data.get('role_kw')
 
     conn = get_connection()
     c    = conn.cursor()


### PR DESCRIPTION
## Summary
- Accept role keyword from JSON when assigning chat roles
- Replace existing ticket/cotizar records and insert new role mapping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc5db6512c8323b50d97bd30c3521f