### PR TITLE
Anchura de role-drop-zone y mejoras visuales

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -311,11 +311,15 @@
     }
 
     .role-drop-zone {
-      position: fixed;
+      position: absolute;
       bottom: 8px;
       left: 8px;
       display: flex;
       gap: 12px;
+      background: var(--bg-sidebar);
+      padding: 8px;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
     }
 
     .role-icon {
@@ -329,6 +333,12 @@
       cursor: pointer;
       font-size: 24px;
       padding: 0 12px;
+      transition: background 0.3s, box-shadow 0.3s;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+
+    .role-icon:hover {
+      box-shadow: 0 4px 8px rgba(0,0,0,0.15);
     }
 
     .role-icon.drag-over {


### PR DESCRIPTION
## Summary
- Ajusta `.role-drop-zone` para posicionarla de forma absoluta dentro de la barra lateral y darle fondo, padding, bordes redondeados y sombra.
- Añade transición y sombras a `.role-icon` para un aspecto más pulido.

## Testing
- `pytest`
- `python app.py` (servidor inicia, se verificó manualmente)


------
https://chatgpt.com/codex/tasks/task_e_68bc6df58dc08323a5c6cbc1e8202a32