### PR TITLE
Adjust chat status colors for clarity

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -140,8 +140,8 @@
       pointer-events: none;
     }
     .estado-sin_regla { background-color: #ff4d4f; color: var(--text-light); }
-    .estado-espera_usuario { background-color: green; color: var(--text-light); }
-    .estado-asesor { background-color: yellow; color: var(--text-main); }
+    .estado-espera_usuario { background-color: #ffc107; color: var(--text-main); }
+    .estado-asesor { background-color: #28a745; color: var(--text-light); }
 
     /* Chat window */
     .chatWindow { flex:1; display:flex; flex-direction:column; }


### PR DESCRIPTION
## Summary
- update `.estado-espera_usuario` to yellow with dark text
- update `.estado-asesor` to green with light text

## Testing
- `pytest`
- `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_68bf147831048323a7aadae2eefe9fe6