### PR TITLE
feat: broadcast chat state over websockets

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 # app.py
 from flask import Flask
+from flask_socketio import SocketIO
 from dotenv import load_dotenv
 import os
 import logging
@@ -16,10 +17,14 @@ from routes.tablero_routes import tablero_bp
 
 load_dotenv()
 
+socketio = SocketIO()
+
+
 def create_app():
     app = Flask(__name__)
     # Si usas clase de config:
     app.config.from_object(Config)
+    socketio.init_app(app, cors_allowed_origins="*")
 
     if not app.debug:
         log_format = '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
@@ -52,4 +57,4 @@ app = create_app()
 
 if __name__ == '__main__':
     port = int(os.getenv('PORT', 5000))
-    app.run(host='0.0.0.0', port=port)
+    socketio.run(app, host='0.0.0.0', port=port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask
 flask-socketio
+eventlet
 python-dotenv
 requests
 gunicorn

--- a/services/db.py
+++ b/services/db.py
@@ -377,7 +377,16 @@ def update_chat_state(numero, step, estado=None):
         (numero, step, estado),
     )
     conn.commit()
+    c.execute("SELECT estado FROM chat_state WHERE numero=%s", (numero,))
+    row = c.fetchone()
+    current_estado = row[0] if row else estado
     conn.close()
+
+    try:
+        from app import socketio
+        socketio.emit('chat_estado', {'numero': numero, 'estado': current_estado})
+    except Exception:
+        pass
 
 
 def delete_chat_state(numero):

--- a/templates/index.html
+++ b/templates/index.html
@@ -51,7 +51,7 @@
   <div id="contextMenu" class="context-menu"><div id="replyAction">Responder</div></div>
 
   <div class="role-indicator">{{ rol }}</div>
-
+  <script src="https://cdn.socket.io/4.6.1/socket.io.min.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
       let currentChat = null, autoRefresh = null, todosChats = [], lastCount = 0, replyTo = null;
@@ -64,7 +64,18 @@
       const replyAction = document.getElementById('replyAction');
         const userRole   = "{{ rol }}";
         const userRoleId = {{ role_id | tojson }};
-        const lastChatTimestamps = {};
+      const lastChatTimestamps = {};
+
+      const socket = io();
+      socket.on('chat_estado', ({ numero, estado }) => {
+        const li = document.querySelector(`#chatList li[data-numero="${numero}"]`);
+        if (li) {
+          li.classList.forEach(cls => { if (cls.startsWith('estado-')) li.classList.remove(cls); });
+          if (estado) li.classList.add('estado-' + estado);
+        } else {
+          fetchChatList();
+        }
+      });
 
         function playAlertSound() {
         const ctx = new (window.AudioContext || window.webkitAudioContext)();
@@ -158,6 +169,7 @@
               }
               if (serverTime) lastChatTimestamps[c.numero] = serverTime;
               const li = document.createElement('li');
+              li.dataset.numero = c.numero;
               li.textContent = c.alias ? `${c.alias} (${c.numero})` : c.numero;
               if (c.estado) li.classList.add('estado-' + c.estado);
 
@@ -442,8 +454,7 @@
 
       // Inicializa
       fetchChatList();
-      setInterval(fetchChatList, 5000); // intervalo según necesidad
-      // TODO: sustituir el sondeo por WebSockets o Server-Sent Events para actualizaciones en tiempo real
+      // Actualizaciones en tiempo real vía WebSockets
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- stream chat state changes to clients via Socket.IO
- update chat list in real time without polling

## Testing
- `pytest`
- `python -m py_compile app.py services/db.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf17cb0ca48323b20fb57b1baf0309