### PR TITLE
Add pending state for new chats

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -381,6 +381,9 @@ def webhook():
                         mime_type=mime_clean,
                     )
 
+                    step = get_current_step(from_number)
+                    update_chat_state(from_number, step, 'sin_respuesta')
+
                     queued = enqueue_transcription(
                         path,
                         from_number,
@@ -423,6 +426,9 @@ def webhook():
                         mime_type=mime_clean
                     )
 
+                    step = get_current_step(from_number)
+                    update_chat_state(from_number, step, 'sin_respuesta')
+
                     # 4) Registro interno
                     logging.info("Video recibido: %s", media_id)
                     continue
@@ -440,6 +446,8 @@ def webhook():
                         media_id=media_id,
                         media_url=media_url
                     )
+                    step = get_current_step(from_number)
+                    update_chat_state(from_number, step, 'sin_respuesta')
                     logging.info("Imagen recibida: %s", media_id)
                     continue
 
@@ -454,6 +462,8 @@ def webhook():
                         wa_id=wa_id,
                         reply_to_wa_id=reply_to_id,
                     )
+                    step = get_current_step(from_number)
+                    update_chat_state(from_number, step, 'sin_respuesta')
                     with cache_lock:
                         message_buffer.setdefault(from_number, []).append(normalized_text)
                         if from_number in pending_timers:
@@ -473,6 +483,8 @@ def webhook():
                         wa_id=wa_id,
                         reply_to_wa_id=reply_to_id,
                     )
+                    step = get_current_step(from_number)
+                    update_chat_state(from_number, step, 'sin_respuesta')
                     if handle_option_reply(from_number, option_id):
                         continue
                     normalized_text = normalize_text(text)

--- a/static/style.css
+++ b/static/style.css
@@ -140,6 +140,7 @@
       pointer-events: none;
     }
     .estado-sin_regla { background-color: #ff4d4f; color: var(--text-light); }
+    .estado-sin_respuesta { background-color: #ff4d4f; color: var(--text-light); }
     .estado-espera_usuario { background-color: #ffc107; color: var(--text-main); }
     .estado-asesor { background-color: #28a745; color: var(--text-light); }
 


### PR DESCRIPTION
## Summary
- mark chats as "sin_respuesta" after storing incoming messages
- style chat list entries for the new "sin_respuesta" state

## Testing
- `pytest`
- Simulated text webhook request with Flask test client

------
https://chatgpt.com/codex/tasks/task_e_68bf1b47d4488323822874ec503f4565