### PR TITLE
Show role keywords with badges in chat list

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -237,11 +237,8 @@ def get_chat_list():
         fila_roles = c.fetchone()
         roles = fila_roles[0] if fila_roles else None
         nombres_roles = fila_roles[1] if fila_roles else None
-        inicial_rol = None
-        if nombres_roles:
-            primer_nombre = nombres_roles.split(',')[0].strip()
-            if primer_nombre:
-                inicial_rol = primer_nombre[0].upper()
+        role_keywords = [n.strip() for n in nombres_roles.split(',')] if nombres_roles else []
+        inicial_rol = role_keywords[0][0].upper() if role_keywords else None
 
         # Estado actual del chat
         c.execute("SELECT estado FROM chat_state WHERE numero = %s", (numero,))
@@ -253,6 +250,7 @@ def get_chat_list():
             "alias":  alias,
             "asesor": requiere_asesor,
             "roles": roles,
+            "roles_kw": role_keywords,
             "inicial_rol": inicial_rol,
             "estado": estado,
             "last_timestamp": last_ts,

--- a/static/style.css
+++ b/static/style.css
@@ -124,19 +124,16 @@
       background:var(--accent); color:var(--text-light);
     }
     #chatList li .badge {
-      position: absolute;
-      right: 1cm;                /* mueve la bolita a la posición deseada */
-      top: 50%;
-      transform: translateY(-50%);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-left: 4px;
       width: 20px;
       height: 20px;
       border-radius: 50%;
       background: var(--accent);
       color: var(--text-light);
       font-size: 12px;
-      display: flex;
-      align-items: center;       /* centra verticalmente */
-      justify-content: center;   /* centra el contenido */
       pointer-events: none;
     }
     .estado-sin_regla { background-color: #ff4d4f; color: var(--text-light); }

--- a/templates/index.html
+++ b/templates/index.html
@@ -63,8 +63,8 @@
       const contextMenu = document.getElementById('contextMenu');
       const replyAction = document.getElementById('replyAction');
         const userRole   = "{{ rol }}";
-        const userRoleId = {{ role_id | tojson }};
         const lastChatTimestamps = {};
+        const roleIcons = { ventas: '💼', soporte: '🛠', marketing: '📣' };
 
         function playAlertSound() {
         const ctx = new (window.AudioContext || window.webkitAudioContext)();
@@ -147,8 +147,8 @@
             chatListEl.innerHTML='';
             data.forEach(c => {
               if (userRole !== 'admin') {
-                const roles = c.roles ? c.roles.split(',').map(Number) : [];
-                if (!roles.includes(userRoleId)) return;
+                const roles = c.roles_kw || [];
+                if (!roles.includes(userRole)) return;
               }
               const serverTime = c.last_timestamp ? new Date(c.last_timestamp).getTime() : null;
               const prevTime = lastChatTimestamps[c.numero];
@@ -166,14 +166,15 @@
                 e.dataTransfer.setData('text/plain', c.numero);
               });
 
-              // Badge con inicial del rol
-              const oldBadge = li.querySelector('.badge');
-              if (oldBadge) oldBadge.remove();
-              if (c.inicial_rol) {
-                const badge = document.createElement('span');
-                badge.className = 'badge';
-                badge.textContent = c.inicial_rol;
-                li.appendChild(badge);
+              // Badges por roles
+              li.querySelectorAll('.badge').forEach(b => b.remove());
+              if (c.roles_kw && c.roles_kw.length) {
+                c.roles_kw.forEach(r => {
+                  const badge = document.createElement('span');
+                  badge.className = 'badge';
+                  badge.textContent = roleIcons[r] || r.charAt(0).toUpperCase();
+                  li.appendChild(badge);
+                });
               }
 
               // Al hacer clic, seleccionar el chat


### PR DESCRIPTION
## Summary
- build `role_keywords` for chats and expose as `roles_kw`
- display a badge per role keyword and filter by keyword on the frontend
- adjust badge styling for multiple role indicators

## Testing
- `python -m py_compile routes/chat_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf21c6cae083238b734a86e138e6c7