### PR TITLE
Add Tiquetes and Cotizar roles to DB seed

### DIFF
--- a/services/db.py
+++ b/services/db.py
@@ -279,6 +279,18 @@ def init_db():
     """, ('Administrador', 'admin', 'admin'))
 
     c.execute("""
+    INSERT INTO roles (name, keyword)
+      SELECT %s, %s FROM DUAL
+      WHERE NOT EXISTS (SELECT 1 FROM roles WHERE keyword=%s)
+    """, ('Tiquetes', 'tiquetes', 'tiquetes'))
+
+    c.execute("""
+    INSERT INTO roles (name, keyword)
+      SELECT %s, %s FROM DUAL
+      WHERE NOT EXISTS (SELECT 1 FROM roles WHERE keyword=%s)
+    """, ('Cotizar', 'cotizar', 'cotizar'))
+
+    c.execute("""
     INSERT IGNORE INTO user_roles (user_id, role_id)
     SELECT u.id, r.id
       FROM usuarios u, roles r


### PR DESCRIPTION
## Summary
- seed `Tiquetes` and `Cotizar` roles in `init_db`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from services.db import init_db
try:
    init_db()
    print('init_db completed')
except Exception as e:
    print('init_db failed:', e)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bf228c60d083238d707f3cd673c299