### PR TITLE
Align role badges with flex container

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -114,7 +114,7 @@
       cursor:pointer; transition:background 0.3s,transform 0.2s;
       color:var(--text-main);
       padding-left:12px;
-      padding-right: calc(2cm + 20px);
+      display:flex; justify-content:space-between; align-items:center;
     }
     #chatList li:hover {
       background:var(--accent-hover); color:var(--text-light);
@@ -123,11 +123,14 @@
     #chatList li.active {
       background:var(--accent); color:var(--text-light);
     }
+    .badges {
+      display:flex;
+      gap:4px;
+    }
     #chatList li .badge {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      margin-left: 8px;
       width: 20px;
       height: 20px;
       border-radius: 50%;

--- a/templates/index.html
+++ b/templates/index.html
@@ -171,13 +171,17 @@
 
               // Badges por roles
               li.querySelectorAll('.badge').forEach(b => b.remove());
+              li.querySelectorAll('.badges').forEach(bc => bc.remove());
+              const badgeContainer = document.createElement('span');
+              badgeContainer.className = 'badges';
               if (c.roles_kw && c.roles_kw.length) {
                 c.roles_kw.forEach(r => {
                   const badge = document.createElement('span');
                   badge.className = 'badge';
                   badge.textContent = roleIcons[r] || r.charAt(0).toUpperCase();
-                  li.appendChild(badge);
+                  badgeContainer.appendChild(badge);
                 });
+                li.appendChild(badgeContainer);
               }
 
               // Al hacer clic, seleccionar el chat


### PR DESCRIPTION
## Summary
- group chat role icons inside a `badges` container and append after rendering
- use flex layout for chat list items and badges for proper alignment

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf2e3406a48323bcbf91cfd1041c24