### PR TITLE
feat: add mobile media query for chat layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -476,3 +476,16 @@
     .back-btn:hover {
       background: var(--accent-hover);
     }
+@media (max-width: 768px) {
+  .container {
+    flex-direction: column;
+    margin: 8px;
+  }
+
+  .sidebar,
+  .chatWindow {
+    width: 100%;
+    height: auto;
+    padding: 10px;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive media query for screens <= 768px
- stack layout vertically and give sidebar/chat padding for mobile

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf334f8e248323a92e632f4efc357b