### PR TITLE
Handle chat body height on mobile

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -31,7 +31,7 @@
     }
     body.chat {
       display: flex;
-      height: 100vh;
+      min-height: 100vh;
     }
     body.page {
       padding: 20px;


### PR DESCRIPTION
## Summary
- use min-height:100vh for chat layout to avoid mobile navigation bar issues

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf33bfc8248323a9c88e493bb500f8