### PR TITLE
Limit media elements and prevent table overflow

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -20,8 +20,12 @@
       --font-base: 'Segoe UI', sans-serif;
     }
 
-    * { box-sizing: border-box; margin:0; padding:0; }
-    body {
+      * { box-sizing: border-box; margin:0; padding:0; }
+      img, video, canvas {
+        max-width: 100%;
+        height: auto;
+      }
+      body {
       font-family: var(--font-base);
       background: var(--bg-page);
       background-image: url("/static/fondo_general.jpeg");
@@ -410,20 +414,21 @@
       }
     }
 
-    table {
+      table {
+        width: 100%;
+        table-layout: fixed;
+      }
+      /* Contenedor reutilizable para tablas amplias con desplazamiento */
+      .fixed-table {
       width: 100%;
-      table-layout: fixed;
-    }
-    .fixed-table {
-    width: 100%;
-    max-width: none;  /* antes: 800px */
-    max-height: 400px;
-    overflow-x: auto;
-    overflow-y: auto;
-    word-break: break-word;
-    white-space: normal;
-    margin: 0 auto;
-    }
+      max-width: none;  /* antes: 800px */
+      max-height: 400px;
+      overflow-x: auto;
+      overflow-y: auto;
+      word-break: break-word;
+      white-space: normal;
+      margin: 0 auto;
+      }
     th, td {
       padding: 10px;
       text-align: left;


### PR DESCRIPTION
## Summary
- Ensure images, videos and canvases scale responsively within their containers
- Document and retain `.fixed-table` overflow handling for wide tables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf3451bf6c832399f188bb5aec13ba