### PR TITLE
Center role drop zone on small screens

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -493,4 +493,10 @@
     height: auto;
     padding: 10px;
   }
+
+  .role-drop-zone {
+    position: static;
+    justify-content: center;
+    margin-top: 10px;
+  }
 }


### PR DESCRIPTION
## Summary
- Center the role drop zone within small screen layouts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf369aa17c83238c574d7340051369