### PR TITLE
Reposition role indicator for mobile view

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -499,4 +499,10 @@
     justify-content: center;
     margin-top: 10px;
   }
+
+  .role-indicator {
+    bottom: auto;
+    top: 8px;
+    right: 8px;
+  }
 }


### PR DESCRIPTION
## Summary
- Adjust role indicator placement on screens <=768px so it doesn't cover controls

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf374aed088323b664c31d00a135bc