### PR TITLE
Improve chat list item wrapping for readability

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -119,6 +119,10 @@
       color:var(--text-main);
       padding-left:12px;
       display:flex; justify-content:space-between; align-items:center;
+      flex-wrap: wrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      min-width: 0;
     }
     #chatList li:hover {
       background:var(--accent-hover); color:var(--text-light);


### PR DESCRIPTION
## Summary
- allow chat list items to wrap and truncate gracefully

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf37cc16d88323ac807ba16d5ba780