### PR TITLE
fix: constrain chat layout scrolling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -36,6 +36,7 @@
     body.chat {
       display: flex;
       min-height: 100vh;
+      overflow: hidden;
     }
     body.page {
       padding: 20px;
@@ -153,7 +154,12 @@
     .estado-asesor { background-color: #28a745; color: var(--text-light); }
 
     /* Chat window */
-    .chatWindow { flex:1; display:flex; flex-direction:column; }
+    .chatWindow {
+      flex:1;
+      display:flex;
+      flex-direction:column;
+      height: 100vh;
+    }
     #botonera {
       display:flex; gap:8px; padding:12px;
       background: var(--bg-chat);


### PR DESCRIPTION
## Summary
- prevent full-page scroll by hiding overflow on `body.chat`
- keep chat content fixed to viewport with `height: 100vh`
- preserve chat message area scrollability

## Testing
- `pytest -q`
- `npm run lint` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3d3aa9948323ac069ed06b9fa5f1