### PR TITLE
Enable scrolling on desktop chat pages

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -36,7 +36,7 @@
     body.chat {
       display: flex;
       min-height: 100vh;
-      overflow: hidden;
+      overflow: auto;
     }
     body.page {
       padding: 20px;
@@ -491,6 +491,11 @@
     .back-btn:hover {
       background: var(--accent-hover);
     }
+@media (min-width: 769px) {
+  body.chat {
+    overflow: auto;
+  }
+}
 @media (max-width: 768px) {
   body.chat {
     overflow: hidden;


### PR DESCRIPTION
## Summary
- Allow desktop chat pages to scroll by default
- Add explicit desktop media query and keep existing mobile overflow rules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf4080aba483239bd84facb7f3eaf5