### PR TITLE
Wrap content in responsive page wrapper

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -25,7 +25,7 @@
         max-width: 100%;
         height: auto;
       }
-      body {
+    body {
       font-family: var(--font-base);
       background: var(--bg-page);
       background-image: url("/static/fondo_general.jpeg");
@@ -42,6 +42,16 @@
       padding: 20px;
       background: #fff;
       background-image: none;
+    }
+    .page-wrapper {
+      width: 100%;
+    }
+
+    @media (min-width: 1024px) {
+      .page-wrapper {
+        width: 1024px;
+        margin: 0 auto;
+      }
     }
     .container {
       flex: 1;

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body class="{% block body_class %}{% endblock %}">
-  {% block content %}{% endblock %}
+  <div class="page-wrapper">
+    {% block content %}{% endblock %}
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Enclose base template content in a new `<div class="page-wrapper">`.
- Add `.page-wrapper` styles and a desktop-only media query to fix width and center the layout.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf41e373608323b249ae2a62a421ca