### PR TITLE
Hide mobile role panel behind toggle

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -64,6 +64,17 @@
       font-size: 24px;
       cursor: pointer;
     }
+
+    #roleToggle {
+      display: none;
+      background: var(--accent-neon);
+      border: none;
+      color: var(--text-light);
+      padding: 8px;
+      font-size: 24px;
+      cursor: pointer;
+      margin-top: 10px;
+    }
     /* Sidebar */
     .sidebar {
       width:25%; background:var(--bg-sidebar);
@@ -548,6 +559,15 @@
     position: static;
     justify-content: center;
     margin-top: 10px;
+    display: none;
+  }
+
+  .role-drop-zone.show {
+    display: flex;
+  }
+
+  #roleToggle {
+    display: block;
   }
 
   .role-indicator {

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,6 +21,7 @@
       </div>
       <input id="buscador" type="text" placeholder="Buscar número…">
       <ul id="chatList"></ul>
+      <button id="roleToggle">🎭</button>
       <div class="role-drop-zone">
         {% for r in roles %}
         <div class="role-icon" data-role="{{ r[2] }}">{{ r[1] }}</div>
@@ -67,6 +68,11 @@
       const menuToggle = document.getElementById('menuToggle');
       menuToggle.addEventListener('click', () => {
         sidebar.classList.toggle('visible');
+      });
+      const roleToggle = document.getElementById('roleToggle');
+      const roleDropZone = document.querySelector('.role-drop-zone');
+      roleToggle.addEventListener('click', () => {
+        roleDropZone.classList.toggle('show');
       });
         const userRole   = "{{ rol }}";
         const lastChatTimestamps = {};


### PR DESCRIPTION
## Summary
- Hide role drag-and-drop area on small screens and display it only when toggled
- Add button to reveal role area and JavaScript to toggle visibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf4a8a89c883238db3d5290c7a2502