### PR TITLE
Use dynamic viewport height and allow chat window flex

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -36,7 +36,7 @@
     }
     body.chat {
       display: flex;
-      min-height: 100vh;
+      height: calc(var(--vh) * 100);
       overflow: auto;
     }
     body.page {
@@ -48,6 +48,7 @@
       flex: 1;
       display: flex;
       margin: 16px;
+      min-height: 0;
       border-radius: 24px;
       overflow: hidden;
       box-shadow: 0 4px 12px rgba(0,0,0,0.1);


### PR DESCRIPTION
## Summary
- Use dynamic viewport height for chat pages using custom --vh variable
- Allow chat window to flex by setting container min-height to 0

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf531dfff48323a963c3325cbfc412