### PR TITLE
Add responses view for bot messages

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,7 @@
 {% block body_class %}chat{% endblock %}
 {% block content %}
   <button id="menuToggle">☰</button>
+  <button id="verRespuestasBtn">Ver respuestas</button>
   <div class="container">
     <!-- Sidebar -->
     <div class="sidebar">
@@ -70,9 +71,15 @@
       const replyAction = document.getElementById('replyAction');
       const sidebar = document.querySelector('.sidebar');
       const menuToggle = document.getElementById('menuToggle');
+      const verRespuestasBtn = document.getElementById('verRespuestasBtn');
       menuToggle.addEventListener('click', () => {
         sidebar.classList.toggle('visible');
       });
+      verRespuestasBtn.onclick = () => {
+        if (currentChat) {
+          window.open('/respuestas/' + currentChat, '_blank');
+        }
+      };
       const roleToggle = document.getElementById('roleToggle');
       const roleDropZone = document.querySelector('.role-drop-zone');
       roleToggle.addEventListener('click', () => {

--- a/templates/respuestas.html
+++ b/templates/respuestas.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block title %}Respuestas{% endblock %}
+{% block body_class %}page{% endblock %}
+{% block content %}
+<div class="top-right">
+    <a href="{{ url_for('chat.index') }}">
+        <button class="back-btn btn-primary">Volver al inicio</button>
+    </a>
+</div>
+
+<h2>Respuestas</h2>
+<table class="fixed-table">
+    <tr>
+        <th>Timestamp</th>
+        <th>Mensaje</th>
+        <th>Tipo</th>
+        <th>Media URL</th>
+    </tr>
+    {% for r in respuestas %}
+    <tr>
+        <td>{{ r.timestamp }}</td>
+        <td>{{ r.mensaje }}</td>
+        <td>{{ r.tipo }}</td>
+        <td>{{ r.media_url or '-' }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `/respuestas/<numero>` route to show bot messages
- create `respuestas.html` template with table of responses
- add "Ver respuestas" button and script on main page

## Testing
- `python -m py_compile routes/chat_routes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf693766dc83238d60eebe9039e853