### PR TITLE
Remove obsolete respuestas button

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,6 @@
 {% block body_class %}chat{% endblock %}
 {% block content %}
   <button id="menuToggle">☰</button>
-  <button id="verRespuestasBtn">Ver respuestas</button>
   <div class="container">
     <!-- Sidebar -->
     <div class="sidebar">
@@ -71,15 +70,9 @@
       const replyAction = document.getElementById('replyAction');
       const sidebar = document.querySelector('.sidebar');
       const menuToggle = document.getElementById('menuToggle');
-      const verRespuestasBtn = document.getElementById('verRespuestasBtn');
       menuToggle.addEventListener('click', () => {
         sidebar.classList.toggle('visible');
       });
-      verRespuestasBtn.onclick = () => {
-        if (currentChat) {
-          window.open('/respuestas/' + currentChat, '_blank');
-        }
-      };
       const roleToggle = document.getElementById('roleToggle');
       const roleDropZone = document.querySelector('.role-drop-zone');
       roleToggle.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- remove responses button from chat UI
- drop unused JavaScript handler for opening responses page

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf6dfeb67c83238d9590793a822fcc