### PR TITLE
Display step summary in responses view

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 import json
+from collections import Counter
 from flask import Blueprint, render_template, request, redirect, session, url_for, jsonify
 from werkzeug.utils import secure_filename
 from config import Config
@@ -166,9 +167,19 @@ def respuestas(numero):
             steps_set.add(key)
         respuestas.append(base)
 
+    step_counter = Counter(
+        step
+        for r in respuestas
+        for key, step in r.items()
+        if key.startswith('step')
+    )
+    summary = dict(step_counter)
+
     steps = sorted(steps_set, key=lambda x: int(x[4:]))
     conn.close()
-    return render_template('respuestas.html', respuestas=respuestas, steps=steps)
+    return render_template(
+        'respuestas.html', respuestas=respuestas, steps=steps, summary=summary
+    )
 
 @chat_bp.route('/send_message', methods=['POST'])
 def send_message():

--- a/templates/respuestas.html
+++ b/templates/respuestas.html
@@ -9,6 +9,21 @@
 </div>
 
 <h2>Respuestas</h2>
+{% if summary %}
+<h3>Resumen</h3>
+<table class="summary-table">
+    <tr>
+        <th>Regla/Step</th>
+        <th>Cantidad</th>
+    </tr>
+    {% for step, count in summary.items() %}
+    <tr>
+        <td>{{ step }}</td>
+        <td>{{ count }}</td>
+    </tr>
+    {% endfor %}
+</table>
+{% endif %}
 <table class="fixed-table">
     <tr>
         <th>Timestamp</th>


### PR DESCRIPTION
## Summary
- Count occurrences of each step in chat responses and expose summary to template
- Render a summary table in `respuestas.html` for quick rule statistics

## Testing
- `python -m py_compile routes/chat_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68c07f829d8883238f8927f6c7bb9471