### PR TITLE
Enlace de respuestas dinámico según chat activo

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
         <a href="{{ url_for('roles.roles') }}">Roles</a>
         {% endif %}
         <a href="{{ url_for('tablero.tablero') }}">Tablero</a>
-        <a id="respuestasLink" href="#">Respuestas</a>
+        <a id="respuestasLink" href="{{ url_for('chat.respuestas', numero='') }}">Respuestas</a>
         <a href="{{ url_for('auth.logout') }}">Cerrar sesión</a>
       </div>
       <input id="buscador" type="text" placeholder="Buscar número…">
@@ -160,10 +160,13 @@
 
       const respuestasLink = document.getElementById('respuestasLink');
       respuestasLink.addEventListener('click', e => {
-        e.preventDefault();
-        if (currentChat) {
-          window.location.href = `/respuestas/${currentChat}`;
+        if (!currentChat) {
+          e.preventDefault();
+          alert('Selecciona un chat primero');
+          return;
         }
+        e.preventDefault();
+        window.location.href = "{{ url_for('chat.respuestas', numero='') }}" + encodeURIComponent(currentChat);
       });
 
       // Cargar lista de chats


### PR DESCRIPTION
## Summary
- Generar ruta base para `Respuestas` con `url_for`.
- Redirigir dinámicamente a la vista de respuestas del chat seleccionado y alertar cuando no hay chat activo.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node - <<'NODE'
let currentChat = null;
const window = { location: { href: '' } };
function alert(msg){ console.log('ALERT:', msg); }
function handler(e){
  if (!currentChat) {
    e.preventDefault();
    alert('Selecciona un chat primero');
    return;
  }
  e.preventDefault();
  window.location.href = "/respuestas/" + encodeURIComponent(currentChat);
}
const event = { preventDefault: () => console.log('preventDefault') };
console.log('==Sin chat seleccionado==');
handler(event);
console.log('href actual:', window.location.href);
currentChat = '54321';
console.log('==Con chat seleccionado==');
handler(event);
console.log('href actual:', window.location.href);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68c081828d308323abfdc442d8180675