### PR TITLE
Add conversation export route

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from routes.configuracion import config_bp
 from routes.roles_routes import roles_bp
 from routes.webhook import webhook_bp
 from routes.tablero_routes import tablero_bp
+from routes.export_routes import export_bp
 
 load_dotenv()
 
@@ -39,6 +40,7 @@ def create_app():
     app.register_blueprint(roles_bp)
     app.register_blueprint(webhook_bp)
     app.register_blueprint(tablero_bp)
+    app.register_blueprint(export_bp)
 
     # Inicializa BD solo si se pide explícitamente y dentro del app_context
     if os.getenv("INIT_DB_ON_START", "0") == "1":

--- a/routes/export_routes.py
+++ b/routes/export_routes.py
@@ -1,0 +1,24 @@
+from flask import Blueprint, jsonify, Response
+import csv
+import io
+
+from services.db import get_conversation
+
+export_bp = Blueprint('export', __name__)
+
+@export_bp.route('/export/conversation/<numero>')
+def export_conversation_json(numero):
+    data = get_conversation(numero)
+    return jsonify(data)
+
+@export_bp.route('/export/conversation/<numero>.csv')
+def export_conversation_csv(numero):
+    data = get_conversation(numero)
+    output = io.StringIO()
+    writer = csv.writer(output)
+    headers = list(data.keys())
+    writer.writerow(headers)
+    writer.writerow([data[h] for h in headers])
+    response = Response(output.getvalue(), mimetype='text/csv')
+    response.headers['Content-Disposition'] = f'attachment; filename=conversation_{numero}.csv'
+    return response


### PR DESCRIPTION
## Summary
- Add get_conversation to build conversation view by joining messages and rules
- Expose conversation export via JSON and CSV endpoints
- Register new export blueprint

## Testing
- `python -m py_compile services/db.py routes/export_routes.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c098bdced0832387d38c3d2dc04586