### PR TITLE
feat: show responses for all conversations

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
         <a href="{{ url_for('roles.roles') }}">Roles</a>
         {% endif %}
         <a href="{{ url_for('tablero.tablero') }}">Tablero</a>
-        <a id="respuestasLink" href="{{ url_for('chat.respuestas', numero='') }}">Respuestas</a>
+        <a id="respuestasLink" href="{{ url_for('chat.respuestas') }}">Respuestas</a>
         <a href="{{ url_for('auth.logout') }}">Cerrar sesión</a>
       </div>
       <input id="buscador" type="text" placeholder="Buscar número…">
@@ -158,16 +158,6 @@
       };
       document.addEventListener('click', () => settingsMenu.classList.remove('show'));
 
-      const respuestasLink = document.getElementById('respuestasLink');
-      respuestasLink.addEventListener('click', e => {
-        if (!currentChat) {
-          e.preventDefault();
-          alert('Selecciona un chat primero');
-          return;
-        }
-        e.preventDefault();
-        window.location.href = "{{ url_for('chat.respuestas', numero='') }}" + encodeURIComponent(currentChat);
-      });
 
       // Cargar lista de chats
       function fetchChatList() {

--- a/templates/respuestas.html
+++ b/templates/respuestas.html
@@ -26,22 +26,26 @@
 {% endif %}
 <table class="fixed-table">
     <tr>
+        <th>Numero</th>
         <th>Timestamp</th>
         <th>Mensaje</th>
         <th>Tipo</th>
         <th>Media URL</th>
         {% for step in steps %}
         <th>{{ step|capitalize }}</th>
+        <th>Respuesta usuario {{ step }}</th>
         {% endfor %}
     </tr>
-    {% for r in respuestas %}
+    {% for r in conversaciones %}
     <tr>
+        <td>{{ r.numero }}</td>
         <td>{{ r.timestamp }}</td>
         <td>{{ r.mensaje }}</td>
         <td>{{ r.tipo }}</td>
         <td>{{ r.media_url or '-' }}</td>
         {% for step in steps %}
         <td>{{ r.get(step, '-') }}</td>
+        <td>{{ r.get('respuesta_' ~ step, '-') }}</td>
         {% endfor %}
     </tr>
     {% endfor %}


### PR DESCRIPTION
## Summary
- Aggregate bot and user messages for every chat in `/respuestas`
- Display user replies per step along with step chain and numbers
- Link sidebar to the new global responses view

## Testing
- `python -m py_compile routes/chat_routes.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c09a48577c83238f9a5ffd6151f0c0