### PR TITLE
Handle non-numeric siguiente_step in respuestas

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -185,11 +185,13 @@ def respuestas():
             if regla_id_join:
                 chain.append((regla_id_join, step))
             if siguiente:
-                chain.extend(
-                    (int(s.strip()), s.strip())
-                    for s in siguiente.split(',')
-                    if s.strip()
-                )
+                for s in siguiente.split(','):
+                    s = s.strip()
+                    if not s:
+                        continue
+                    if not s.isdigit():
+                        continue  # o registrar un warning
+                    chain.append((int(s), s))
             for rid, st in chain:
                 key = f'step{rid}'
                 base[key] = st


### PR DESCRIPTION
## Summary
- Skip invalid `siguiente_step` values when building step chains in `/respuestas`
- Ensure only numeric steps are processed

## Testing
- `python - <<'PY'
from routes.chat_routes import respuestas
siguiente = '1, 2,abc, , 3 ,xyz'
chain = []
for s in siguiente.split(','):
    s = s.strip()
    if not s:
        continue
    if not s.isdigit():
        continue
    chain.append((int(s), s))
print(chain)
PY`
- `python -m py_compile routes/chat_routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c09dcdaebc8323be39d040d5292b9b