### PR TITLE
Add dashboard metric for messages without advisor

### DIFF
--- a/static/tablero.js
+++ b/static/tablero.js
@@ -9,7 +9,8 @@ document.addEventListener('DOMContentLoaded', () => {
       chartPalabras,
       chartRoles,
       chartTipos,
-      chartTiposDiarios;
+      chartTiposDiarios,
+      chartSinAsesor;
   const commonOptions = {
     animation: { duration: 1000 },
     interaction: { mode: 'nearest', intersect: false },
@@ -597,6 +598,38 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error(err);
         if (chartTipos) chartTipos.destroy();
         showCardMessage('graficoTipos', 'Error al cargar datos');
+      });
+
+    fetch(`/datos_sin_asesor${query}`)
+      .then(response => response.json())
+      .then(data => {
+        const total = data && typeof data.sin_asesor === 'number' ? data.sin_asesor : null;
+        if (total === null || total === 0) {
+          if (chartSinAsesor) chartSinAsesor.destroy();
+          showCardMessage('graficoSinAsesor', total === 0 ? 'No hay datos disponibles' : 'Error al cargar datos');
+          return;
+        }
+        if (chartSinAsesor) chartSinAsesor.destroy();
+        showCardMessage('graficoSinAsesor');
+        const ctx = document.getElementById('graficoSinAsesor').getContext('2d');
+        chartSinAsesor = new Chart(ctx, {
+          type: 'doughnut',
+          data: {
+            labels: ['Sin Asesor'],
+            datasets: [{
+              data: [total],
+              backgroundColor: ['#FF6384']
+            }]
+          },
+          options: {
+            ...commonOptions
+          }
+        });
+      })
+      .catch(err => {
+        console.error(err);
+        if (chartSinAsesor) chartSinAsesor.destroy();
+        showCardMessage('graficoSinAsesor', 'Error al cargar datos');
       });
 
     fetch(`/datos_tipos_diarios${query}`)

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -200,6 +200,13 @@
                 </div>
                 <canvas id="graficoTiposDiarios"></canvas>
             </div>
+            <div class="card chart-card">
+                <div class="card-header">
+                    <span class="icon">🙅</span>
+                    <h4>Mensajes sin Asesor</h4>
+                </div>
+                <canvas id="graficoSinAsesor"></canvas>
+            </div>
         </section>
     </div>
 </main>


### PR DESCRIPTION
## Summary
- add `/datos_sin_asesor` endpoint counting messages whose type does not start with 'asesor'
- render new "Mensajes sin Asesor" card in dashboard template
- fetch and display count in new Chart.js doughnut chart on dashboard

## Testing
- `python -m py_compile routes/tablero_routes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1bfb62fd08323a52579972e3e6c44