### PR TITLE
Add report for numbers without advisor

### DIFF
--- a/routes/tablero_routes.py
+++ b/routes/tablero_routes.py
@@ -558,6 +558,50 @@ def datos_tipos():
     return jsonify(data)
 
 
+@tablero_bp.route('/datos_numeros_sin_asesor')
+def datos_numeros_sin_asesor():
+    """Devuelve los números y conteos de mensajes cuyo tipo no comienza con 'asesor'."""
+    if "user" not in session:
+        return redirect(url_for('auth.login'))
+
+    start = request.args.get('start')
+    end = request.args.get('end')
+    rol = request.args.get('rol', type=int)
+    numero = request.args.get('numero')
+
+    conn = get_connection()
+    cur = conn.cursor()
+
+    try:
+        joins, filter_conditions, filter_params = _apply_filters(cur, rol, numero)
+    except ValueError as e:
+        conn.close()
+        msg = 'Rol' if str(e) == 'rol' else 'Número'
+        return jsonify({"error": f"{msg} no encontrado"}), 400
+
+    query = "SELECT m.numero, COUNT(*) FROM mensajes m"
+    if joins:
+        query += " " + joins
+
+    conditions = ["(m.tipo IS NULL OR m.tipo NOT LIKE 'asesor%')"]
+    params = []
+    if start and end:
+        conditions.append("m.timestamp BETWEEN %s AND %s")
+        params.extend([start, end])
+    conditions.extend(filter_conditions)
+    params.extend(filter_params)
+    if conditions:
+        query += " WHERE " + " AND ".join(conditions)
+    query += " GROUP BY m.numero"
+
+    cur.execute(query, params)
+    rows = cur.fetchall()
+    conn.close()
+
+    data = [{"numero": num, "mensajes": count} for num, count in rows]
+    return jsonify(data)
+
+
 @tablero_bp.route('/datos_sin_asesor')
 def datos_sin_asesor():
     """Devuelve el total de mensajes cuyo tipo no comienza con 'asesor'."""

--- a/templates/tablero.html
+++ b/templates/tablero.html
@@ -152,6 +152,21 @@
             </div>
             <div class="card chart-card">
                 <div class="card-header">
+                    <span class="icon">🙅📞</span>
+                    <h4>Números sin Asesor</h4>
+                </div>
+                <div class="chart-table">
+                    <canvas id="graficoNumerosSinAsesor"></canvas>
+                    <table id="tabla_numeros_sin_asesor" class="fixed-table">
+                        <thead>
+                            <tr><th>Número</th><th>Mensajes</th></tr>
+                        </thead>
+                        <tbody></tbody>
+                    </table>
+                </div>
+            </div>
+            <div class="card chart-card">
+                <div class="card-header">
                     <span class="icon">🔤</span>
                     <h4>Palabras Más Usadas</h4>
                 </div>


### PR DESCRIPTION
## Summary
- add backend endpoint to list numbers without advisor messages
- visualize numbers without advisor via new chart and table
- render "Números sin Asesor" report on dashboard

## Testing
- `python -m py_compile routes/tablero_routes.py`
- `node -c static/tablero.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1c1bb3d2883238fec44f7625855b5