### PR TITLE
Order chat messages by timestamp

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -108,7 +108,7 @@ def get_chat(numero):
       FROM mensajes m
       LEFT JOIN mensajes r ON r.wa_id = m.reply_to_wa_id
       WHERE m.numero = %s
-      ORDER BY r.id
+      ORDER BY m.timestamp ASC
     """, (numero,))
     mensajes = c.fetchall()
     conn.close()

--- a/services/db.py
+++ b/services/db.py
@@ -67,6 +67,11 @@ def init_db():
     if not c.fetchone():
         c.execute("ALTER TABLE mensajes ADD COLUMN regla_id INT NULL;")
 
+    # Índice sobre timestamp para mejorar el ordenamiento cronológico
+    c.execute("SHOW INDEX FROM mensajes WHERE Key_name = 'idx_mensajes_timestamp';")
+    if not c.fetchone():
+        c.execute("CREATE INDEX idx_mensajes_timestamp ON mensajes (timestamp);")
+
     # mensajes procesados
     c.execute("""
     CREATE TABLE IF NOT EXISTS mensajes_procesados (


### PR DESCRIPTION
## Summary
- Retrieve chat messages ordered by actual message timestamp to ensure chronological delivery
- Add defensive index creation on `mensajes.timestamp` for performant sorting

## Testing
- `python -m py_compile routes/chat_routes.py services/db.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2c929f6ac83239b055220d7bec99c