### PR TITLE
Ajusta consulta y estructura de mensajes en chat

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -161,7 +161,7 @@ def respuestas():
 
         c.execute(
             f"""
-            SELECT m.numero, m.timestamp, m.mensaje, m.tipo, m.media_url,
+            SELECT m.numero, m.timestamp, m.mensaje, m.tipo,
                    r.step, r.siguiente_step, m.regla_id, r.id
               FROM mensajes m
               JOIN reglas r ON m.regla_id = r.id
@@ -173,15 +173,14 @@ def respuestas():
         rows = c.fetchall()
 
         for row in rows:
-            numero, timestamp, mensaje, tipo, media_url, step, siguiente, regla_id, regla_id_join = row
+            numero, timestamp, mensaje, tipo, step, siguiente, regla_id, regla_id_join = row
             base = data_by_numero.setdefault(
                 numero,
                 {
                     'numero': numero,
-                    'timestamp': timestamp,
+                    'fecha': timestamp,
                     'mensaje': mensaje,
                     'tipo': tipo,
-                    'media_url': media_url,
                 },
             )
             chain = []


### PR DESCRIPTION
## Summary
- Elimina la extracción de `media_url` en la consulta de respuestas de bot
- Simplifica el objeto base removiendo `media_url` y usando `fecha` en lugar de `timestamp`

## Testing
- `python -m py_compile routes/chat_routes.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2d18581b4832380c01b16b8f9d44f