### PR TITLE
Reemplazar columna Timestamp por Fecha y eliminar Media URL

### DIFF
--- a/templates/respuestas.html
+++ b/templates/respuestas.html
@@ -27,10 +27,9 @@
 <table class="fixed-table">
     <tr>
         <th>Numero</th>
-        <th>Timestamp</th>
+        <th>Fecha</th>
         <th>Mensaje</th>
         <th>Tipo</th>
-        <th>Media URL</th>
         {% for step in steps %}
         <th>{{ step|capitalize }}</th>
         <th>Respuesta usuario {{ step }}</th>
@@ -39,10 +38,9 @@
     {% for r in conversaciones %}
     <tr>
         <td>{{ r.numero }}</td>
-        <td>{{ r.timestamp }}</td>
+        <td>{{ r.fecha }}</td>
         <td>{{ r.mensaje }}</td>
         <td>{{ r.tipo }}</td>
-        <td>{{ r.media_url or '-' }}</td>
         {% for step in steps %}
         <td>{{ r.get(step, '-') }}</td>
         <td>{{ r.get('respuesta_' ~ step, '-') }}</td>


### PR DESCRIPTION
## Summary
- Cambia el encabezado `Timestamp` por `Fecha` en la tabla de respuestas y usa `r.fecha`.
- Elimina la columna "Media URL" de la tabla.
- La tabla conserva su ancho responsive, sin ajustes adicionales requeridos.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2d406c3408323bbf48805af26b334