### PR TITLE
Fix reply message text display

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -252,7 +252,8 @@
               chatBoxEl.innerHTML = ''; lastCount = 0;
             }
             for (let i=lastCount; i<total; i++){
-              const [txt, tipo, url, ts, linkUrl, linkTitle, linkBody, linkThumb, waId, replyWaId, replyText, replyTipo, replyUrl] = msgs[i];
+              const [txt, tipo, url, ts, linkUrl, linkTitle, linkBody, linkThumb,
+                     waId, replyWaId, replyId, replyText, replyTipo, replyUrl] = msgs[i];
               const div = document.createElement('div');
               // map tipo a bubble class
               let bubble = 'cliente';


### PR DESCRIPTION
## Summary
- include `replyId` in `loadMessages` destructuring so reply text is correctly aligned

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c2d6480b1083238baf827e854ed038