### PR TITLE
Add marketing landing page and public route

### DIFF
--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -5,6 +5,14 @@ from services.db import get_connection, get_roles_by_user
 
 auth_bp = Blueprint('auth', __name__)
 
+
+@auth_bp.route('/')
+def landing():
+    if session.get('user'):
+        return redirect(url_for('chat.index'))
+    return render_template('landing.html')
+
+
 def _verify_password(stored_hash: str, plain: str) -> bool:
     """
     Soporta hashes nuevos de Werkzeug (pbkdf2:...) y legacy sha256 hex.

--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -14,7 +14,7 @@ chat_bp = Blueprint('chat', __name__)
 MEDIA_ROOT = Config.MEDIA_ROOT
 os.makedirs(Config.MEDIA_ROOT, exist_ok=True)
 
-@chat_bp.route('/')
+@chat_bp.route('/app')
 def index():
     # Autenticación
     if "user" not in session:

--- a/static/style.css
+++ b/static/style.css
@@ -8,6 +8,14 @@
       --accent-neon:    #00A884;  /* acento verde neón */
       --bg-glass:       rgba(255,255,255,0.1); /* fondo translúcido */
 
+      --color-orange-light: #ff8a00;
+      --color-orange-dark:  #ff6f00;
+      --color-pink:         #ff4f68;
+      --landing-gradient: radial-gradient(circle at 20% 20%,
+                          rgba(255, 79, 104, 0.85) 0%,
+                          rgba(255, 138, 0, 0.9) 45%,
+                          rgba(255, 111, 0, 0.95) 100%);
+
       --bubble-user:    #D2F5F0;  /* mensajes del cliente */
       --bubble-bot:     #F7F3B7;  /* gris suave, para el bot */
       --bubble-asesor:  #C0F2C9;  /* verde más claro, asesor */
@@ -33,6 +41,22 @@
       background-size: cover;
       background-repeat: repeat;
       background-position: center;
+    }
+    body.landing-page {
+      min-height: 100vh;
+      background-color: #0b1120;
+      background-image: var(--landing-gradient);
+      background-size: cover;
+      background-repeat: no-repeat;
+      background-attachment: fixed;
+      color: #f8fafc;
+      position: relative;
+      overflow-x: hidden;
+    }
+    .landing-overlay {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
     }
     body.chat {
       display: flex;

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,0 +1,178 @@
+{% extends 'base.html' %}
+{% block title %}KiryApp | Todo tu ecosistema conectado{% endblock %}
+{% block body_class %}landing-page{% endblock %}
+{% block content %}
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            'brand-orange': '#ff8a00',
+            'brand-orange-dark': '#ff6f00',
+            'brand-pink': '#ff4f68'
+          },
+          fontFamily: {
+            heading: ['"Poppins"', 'system-ui', 'sans-serif']
+          },
+          boxShadow: {
+            highlight: '0 30px 70px rgba(15, 23, 42, 0.35)'
+          }
+        }
+      }
+    }
+  </script>
+
+  <div class="relative min-h-screen overflow-hidden">
+    <div class="landing-overlay" aria-hidden="true">
+      <div class="absolute -top-24 -right-16 h-72 w-72 rounded-full bg-brand-pink/35 blur-3xl"></div>
+      <div class="absolute top-1/3 -right-32 h-[26rem] w-[26rem] rounded-[60%] bg-brand-orange/30 blur-3xl"></div>
+      <div class="absolute -bottom-24 -right-12 h-56 w-56 rounded-full bg-brand-orange-dark/35 blur-2xl"></div>
+    </div>
+
+    <div class="relative z-10">
+      <header class="max-w-6xl mx-auto flex flex-col gap-6 px-6 pt-8 lg:flex-row lg:items-center lg:justify-between">
+        <div class="flex items-center justify-between">
+          <a href="{{ url_for('auth.landing') }}" class="flex items-center gap-3">
+            <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/10 text-2xl font-bold text-white shadow-lg shadow-black/10">K</span>
+            <span class="font-heading text-2xl font-semibold tracking-wide text-white">KiryApp</span>
+          </a>
+          <button id="mobileMenuButton" class="inline-flex items-center justify-center rounded-xl border border-white/30 bg-white/10 p-2 text-white transition hover:bg-white/20 lg:hidden" aria-expanded="false" aria-controls="mobileMenu">
+            <svg id="menuIcon" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+            </svg>
+            <svg id="closeIcon" class="hidden h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+            </svg>
+            <span class="sr-only">Abrir menú de navegación</span>
+          </button>
+        </div>
+        <nav class="hidden items-center gap-10 text-sm font-medium text-white/80 transition lg:flex">
+          <a class="hover:text-white" href="#conductores">Conductores</a>
+          <a class="hover:text-white" href="#usuarios">Usuarios</a>
+          <a class="hover:text-white" href="#rastreo">Rastrear mis paquetes</a>
+          <a class="inline-flex items-center justify-center rounded-full border border-white/40 px-4 py-2 font-semibold text-white transition hover:border-transparent hover:bg-white/20" href="{{ url_for('auth.login') }}">Ingresar</a>
+        </nav>
+        <div id="mobileMenu" class="hidden flex-col gap-4 rounded-2xl border border-white/20 bg-white/10 p-6 text-sm font-medium text-white/80 backdrop-blur lg:hidden">
+          <a class="hover:text-white" href="#conductores">Conductores</a>
+          <a class="hover:text-white" href="#usuarios">Usuarios</a>
+          <a class="hover:text-white" href="#rastreo">Rastrear mis paquetes</a>
+          <a class="inline-flex items-center justify-center rounded-full border border-white/40 px-4 py-2 font-semibold text-white transition hover:border-transparent hover:bg-white/20" href="{{ url_for('auth.login') }}">Ingresar</a>
+        </div>
+      </header>
+
+      <main class="max-w-6xl mx-auto px-6 pb-20 lg:pb-32">
+        <section class="grid gap-12 pt-12 lg:grid-cols-2 lg:items-center lg:gap-16">
+          <div class="order-last rounded-3xl border border-white/15 bg-white/10 p-8 shadow-highlight backdrop-blur-xl lg:order-2">
+            <div class="flex items-center justify-between text-sm text-white/80">
+              <span class="inline-flex items-center gap-2 font-semibold">
+                <span class="flex h-9 w-9 items-center justify-center rounded-full bg-brand-pink/30 text-lg text-white">🚚</span>
+                Entregas en curso
+              </span>
+              <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Tiempo real</span>
+            </div>
+            <div class="mt-6 space-y-6">
+              <div class="rounded-2xl border border-white/20 bg-white/10 p-4">
+                <div class="flex items-center justify-between text-white">
+                  <p class="text-sm font-medium">Rutas activas</p>
+                  <span class="text-xs uppercase tracking-wide text-white/60">+12%</span>
+                </div>
+                <p class="mt-2 text-3xl font-semibold text-white">128</p>
+                <p class="mt-1 text-xs text-white/70">Monitoreadas por inteligencia predictiva.</p>
+              </div>
+              <div class="grid grid-cols-2 gap-4 text-white/90">
+                <div class="rounded-2xl border border-white/15 bg-white/5 p-4">
+                  <p class="text-xs uppercase tracking-wide text-white/60">Conductores</p>
+                  <p class="mt-1 text-2xl font-semibold text-white">540</p>
+                  <p class="mt-2 text-xs text-white/60">Asignados hoy</p>
+                </div>
+                <div class="rounded-2xl border border-white/15 bg-white/5 p-4">
+                  <p class="text-xs uppercase tracking-wide text-white/60">Paquetes</p>
+                  <p class="mt-1 text-2xl font-semibold text-white">3.2K</p>
+                  <p class="mt-2 text-xs text-white/60">Listos para entrega</p>
+                </div>
+              </div>
+            </div>
+            <div class="mt-6 flex items-center justify-between rounded-2xl border border-white/20 bg-black/20 p-4 text-sm text-white/80">
+              <div>
+                <p class="text-xs uppercase tracking-[0.2em] text-white/60">Satisfacción</p>
+                <p class="text-lg font-semibold text-white">4.9/5</p>
+              </div>
+              <div class="flex -space-x-2">
+                <span class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/30 bg-white/20 text-xs text-white">AO</span>
+                <span class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/30 bg-white/20 text-xs text-white">BT</span>
+                <span class="inline-flex h-8 w-8 items-center justify-center rounded-full border border-white/30 bg-white/20 text-xs text-white">CM</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="order-first space-y-8 lg:order-1">
+            <span class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-black/20 px-4 py-2 text-sm font-semibold uppercase tracking-[0.2em] text-white/70">
+              <span class="h-2 w-2 rounded-full bg-brand-pink"></span>
+              Plataforma logística integrada
+            </span>
+            <h1 class="font-heading text-4xl font-extrabold leading-tight text-white sm:text-5xl lg:text-6xl">¡Todo en el mismo lugar!</h1>
+            <p class="max-w-xl text-lg text-white/80">
+              Centraliza la comunicación con tus conductores, clientes y operaciones de entrega en un panel inteligente que te permite reaccionar en segundos.
+            </p>
+            <div class="flex flex-col gap-4 sm:flex-row sm:items-center">
+              <a href="{{ url_for('auth.login') }}" class="inline-flex items-center justify-center rounded-full bg-brand-pink px-8 py-3 text-base font-semibold text-white shadow-lg shadow-brand-pink/30 transition hover:bg-brand-orange-dark focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white">Regístrate</a>
+              <a href="#rastreo" class="inline-flex items-center gap-2 text-sm font-semibold text-white/80 transition hover:text-white">
+                Conoce cómo funciona
+                <svg class="h-4 w-4" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M5 12h14M13 5l7 7-7 7"></path>
+                </svg>
+              </a>
+            </div>
+            <ul class="grid gap-4 text-sm text-white/80 sm:grid-cols-2">
+              <li class="flex items-start gap-3">
+                <span class="mt-0.5 inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand-orange/40 text-white">📦</span>
+                <div>
+                  <p class="font-semibold text-white">Seguimiento en vivo</p>
+                  <p class="text-white/70">Mapas actualizados y alertas automáticas para tus clientes.</p>
+                </div>
+              </li>
+              <li class="flex items-start gap-3">
+                <span class="mt-0.5 inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand-orange-dark/40 text-white">🤝</span>
+                <div>
+                  <p class="font-semibold text-white">Roles colaborativos</p>
+                  <p class="text-white/70">Coordina equipos de soporte, operaciones y ventas en segundos.</p>
+                </div>
+              </li>
+              <li class="flex items-start gap-3">
+                <span class="mt-0.5 inline-flex h-8 w-8 items-center justify-center rounded-full bg-brand-pink/35 text-white">⚡</span>
+                <div>
+                  <p class="font-semibold text-white">Automatizaciones inteligentes</p>
+                  <p class="text-white/70">Respuestas rápidas y workflows listos para escalar.</p>
+                </div>
+              </li>
+              <li class="flex items-start gap-3">
+                <span class="mt-0.5 inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/15 text-white">📊</span>
+                <div>
+                  <p class="font-semibold text-white">Analítica accionable</p>
+                  <p class="text-white/70">Indicadores claves para optimizar tus entregas diarias.</p>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </section>
+      </main>
+    </div>
+  </div>
+
+  <script>
+    const menuButton = document.getElementById('mobileMenuButton');
+    const mobileMenu = document.getElementById('mobileMenu');
+    const menuIcon = document.getElementById('menuIcon');
+    const closeIcon = document.getElementById('closeIcon');
+
+    if (menuButton && mobileMenu) {
+      menuButton.addEventListener('click', () => {
+        const isOpen = mobileMenu.classList.toggle('hidden');
+        menuButton.setAttribute('aria-expanded', (!isOpen).toString());
+        menuIcon.classList.toggle('hidden');
+        closeIcon.classList.toggle('hidden');
+      });
+    }
+  </script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add palette variables and gradient support for the landing background
- create a Tailwind-based marketing landing page with responsive navigation and hero section
- serve the new landing for unauthenticated users while moving the chat interface to `/app`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c97417d7fc8323b44c6c6766190edb