### PR TITLE
Deshabilitar sonido de alerta al ingresar

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -84,18 +84,8 @@
         const roleIcons = { ventas: '💼', soporte: '🛠', marketing: '📣' };
 
         function playAlertSound() {
-        const ctx = new (window.AudioContext || window.webkitAudioContext)();
-        const oscillator = ctx.createOscillator();
-        const gain = ctx.createGain();
-        oscillator.type = 'sine';
-        oscillator.frequency.value = 880;
-        gain.gain.value = 0.1;
-        oscillator.connect(gain);
-        gain.connect(ctx.destination);
-        oscillator.start();
-        oscillator.stop(ctx.currentTime + 0.2);
-        oscillator.onended = () => ctx.close();
-      }
+          // El sonido de alerta se deshabilita para evitar el tono al ingresar a la interfaz.
+        }
 
       document.querySelectorAll('.role-icon').forEach(icon => {
         icon.addEventListener('dragover', e => {


### PR DESCRIPTION
## Summary
- desactivar la generación del tono de alerta al consultar nuevos chats
- mantener la función `playAlertSound` como no-op para evitar el ruido al ingresar a la interfaz

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3f44786dc8323a84d6985d7a111ce