### PR TITLE
Prevent greeting repetition when a session restarts

### DIFF
--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -321,12 +321,13 @@ def handle_text_message(numero: str, texto: str, save: bool = True):
     if texto and save:
         guardar_mensaje(numero, texto, 'cliente', step=step_db)
 
+    text_norm = normalize_text(texto or "")
+
     if not step_db:
         set_user_step(numero, Config.INITIAL_STEP)
         process_step_chain(numero, 'iniciar')
-        return
-
-    text_norm = normalize_text(texto or "")
+        if not text_norm or text_norm == 'iniciar':
+            return
 
     if handle_global_command(numero, texto):
         return


### PR DESCRIPTION
## Summary
- ensure the chat session reinitialization does not discard the buffered user message
- only skip processing when the incoming text is empty or the iniciar keyword used to trigger the greeting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5a4bb89548323b72a92df39964b2a