### PR TITLE
Load .env before importing Config

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,9 @@ from dotenv import load_dotenv
 import os
 import logging
 import sys
+
+load_dotenv()
+
 from config import Config
 
 from services.db import init_db
@@ -14,8 +17,6 @@ from routes.roles_routes import roles_bp
 from routes.webhook import webhook_bp
 from routes.tablero_routes import tablero_bp
 from routes.export_routes import export_bp
-
-load_dotenv()
 
 def create_app():
     app = Flask(__name__)


### PR DESCRIPTION
## Summary
- call load_dotenv before importing the Config class so .env values populate at import time

## Testing
- python - <<'PY'
from app import Config
print('VERIFY_TOKEN:', Config.VERIFY_TOKEN)
PY
- python - <<'PY'
from app import app
client = app.test_client()
resp = client.get('/webhook', query_string={'hub.verify_token': 'expected_token_value', 'hub.challenge': '123456'})
print('status_ok:', resp.status_code, 'body:', resp.data.decode())
resp = client.get('/webhook', query_string={'hub.verify_token': 'wrong', 'hub.challenge': '123456'})
print('status_wrong:', resp.status_code, 'body:', resp.data.decode())
PY


------
https://chatgpt.com/codex/tasks/task_e_68dab50bebb88323ac0989cb2ff953dc