### PR TITLE
Add flow response reporting to respuestas page

### DIFF
--- a/templates/respuestas.html
+++ b/templates/respuestas.html
@@ -48,4 +48,44 @@
     </tr>
     {% endfor %}
 </table>
+{% if flows %}
+<h3>Flows recibidos</h3>
+<table class="fixed-table flow-table">
+    <tr>
+        <th>Numero</th>
+        <th>Nombre del Flow</th>
+        <th>Respuestas</th>
+    </tr>
+    {% for flow in flows %}
+    <tr>
+        <td>{{ flow.numero }}</td>
+        <td>{{ flow.flow_name or 'Sin nombre' }}</td>
+        <td>
+            <ul class="flow-response-list">
+                {% for resp in flow.responses %}
+                <li>
+                    <div class="flow-response-meta">
+                        {% if resp.timestamp %}<strong>{{ resp.timestamp }}</strong>{% endif %}
+                        {% if resp.wa_id %}<span class="flow-response-waid"> (WA: {{ resp.wa_id }})</span>{% endif %}
+                    </div>
+                    {% set payload = resp.data %}
+                    {% if payload is mapping %}
+                    <pre>{{ payload | tojson(indent=2) }}</pre>
+                    {% elif payload is string %}
+                    <pre>{{ payload }}</pre>
+                    {% elif payload is sequence %}
+                    <pre>{{ payload | tojson(indent=2) }}</pre>
+                    {% elif payload is none %}
+                    <em>Sin contenido</em>
+                    {% else %}
+                    <pre>{{ payload }}</pre>
+                    {% endif %}
+                </li>
+                {% endfor %}
+            </ul>
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- aggregate flow_responses data in the respuestas view and expose it to the template
- render grouped Flow responses alongside existing rule statistics without altering the current layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e02a322250832398be278bf04c479e