### PR TITLE
Normalizar campos de perfil de Instagram y evitar reintentos cuando falla la carga

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -105,7 +105,7 @@ def _fetch_instagram_profile(ig_user_id: str, access_token: str) -> dict | None:
     if not ig_user_id or not access_token:
         return None
     params = {
-        "fields": "name,username,profile_picture_url",
+        "fields": "name,username,profile_pic,profile_picture_url",
         "access_token": access_token,
     }
     url = f"https://graph.facebook.com/{Config.FACEBOOK_GRAPH_API_VERSION}/{ig_user_id}"
@@ -137,11 +137,12 @@ def _fetch_instagram_profile(ig_user_id: str, access_token: str) -> dict | None:
     if not isinstance(payload, dict):
         return None
 
+    profile_picture_url = payload.get("profile_picture_url") or payload.get("profile_pic")
     return {
         "ig_user_id": ig_user_id,
         "name": payload.get("name"),
         "username": payload.get("username"),
-        "profile_picture_url": payload.get("profile_picture_url"),
+        "profile_picture_url": profile_picture_url,
     }
 
 
@@ -243,6 +244,17 @@ def _instagram_profile_worker_loop() -> None:
                         fetched.get("profile_picture_url"),
                         now,
                     ),
+                )
+                conn.commit()
+            else:
+                c.execute(
+                    """
+                    INSERT INTO instagram_profiles (ig_user_id, updated_at)
+                    VALUES (%s, %s)
+                    ON DUPLICATE KEY UPDATE
+                      updated_at = VALUES(updated_at)
+                    """,
+                    (ig_user_id, now),
                 )
                 conn.commit()
             conn.close()


### PR DESCRIPTION
### Motivation
- Some Instagram profiles return `profile_pic` instead of `profile_picture_url`, causing missing avatar URLs. 
- When background fetches fail they kept being retried constantly and spammed logs, so the worker should mark the profile as refreshed to back off.

### Description
- Request both `profile_pic` and `profile_picture_url` in the Instagram Graph call by changing `fields` to `"name,username,profile_pic,profile_picture_url"` in `_fetch_instagram_profile`.
- Normalize the returned avatar by using `payload.get("profile_picture_url") or payload.get("profile_pic")` and return it as `profile_picture_url`.
- In the background worker `_instagram_profile_worker_loop`, insert/update a minimal row with `updated_at` when `_fetch_instagram_profile` returns `None` so the profile is considered refreshed and won't be requeued immediately.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cbf5d4a048323967d04c5a6c40374)