### PR TITLE
Add WhatsApp post-signup insights to Integrations tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ estos pasos desde el contenedor web:
    python scripts/check_embedded_signup.py
    ```
 
-   Esto valida la presencia de `FACEBOOK_APP_ID`, `SIGNUP_FACEBOOK`, la
-   resolución DNS hacia Facebook y que el esquema preferido sea HTTPS.
+   Esto valida la presencia de `FACEBOOK_APP_ID`, `SIGNUP_FACEBOOK`,
+   `WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI`, la resolución DNS hacia Facebook y
+   que el esquema preferido sea HTTPS.
 
 2. Carga `/configuracion/signup` y revisa la sección **Diagnóstico rápido** en la
    tarjeta de Embedded Signup. Marca en tiempo real si falta alguna variable de
@@ -177,6 +178,10 @@ estos pasos desde el contenedor web:
 3. Abre la consola del navegador (F12) para ver errores de red de `sdk.js` o
    bloqueos de terceros. Si el SDK no carga, verifica conectividad saliente o
    políticas de contenido (CSP/proxy).
+
+4. Define `WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI` en el entorno global con la
+   URL exacta aprobada en Meta para OAuth (debe coincidir al intercambiar el
+   `code` por token en `/oauth/access_token`).
 
 ## Comandos globales
 

--- a/config.py
+++ b/config.py
@@ -176,9 +176,14 @@ class Config:
     )
     PUBLIC_BASE_URL = os.getenv('PUBLIC_BASE_URL', '')
     WHATSAPP_OAUTH_REDIRECT_URI = os.getenv('WHATSAPP_OAUTH_REDIRECT_URI', '')
-    EMBEDDED_SIGNUP_REDIRECT_URI = WHATSAPP_OAUTH_REDIRECT_URI or os.getenv(
+    WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI = os.getenv('WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI', '')
+    EMBEDDED_SIGNUP_REDIRECT_URI = (
+        WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI
+        or WHATSAPP_OAUTH_REDIRECT_URI
+        or os.getenv(
         'EMBEDDED_SIGNUP_REDIRECT_URI',
         'https://app.whapco.site/configuracion/signup',
+        )
     )
     PREFERRED_URL_SCHEME = os.getenv('PREFERRED_URL_SCHEME', 'https')
     IA_HISTORY_LIMIT = int(os.getenv('IA_HISTORY_LIMIT', 30))

--- a/scripts/check_embedded_signup.py
+++ b/scripts/check_embedded_signup.py
@@ -49,6 +49,16 @@ def check_env_vars() -> Iterable[CheckResult]:
         bool(Config.SIGNUP_FACEBOOK),
         _mask_value(Config.SIGNUP_FACEBOOK),
     )
+    whatsapp_redirect = (
+        getattr(Config, "WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI", "")
+        or Config.WHATSAPP_OAUTH_REDIRECT_URI
+        or Config.EMBEDDED_SIGNUP_REDIRECT_URI
+    )
+    yield CheckResult(
+        "WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI",
+        bool(whatsapp_redirect),
+        _mask_value(whatsapp_redirect),
+    )
     yield CheckResult(
         "DEFAULT_TENANT",
         bool(Config.DEFAULT_TENANT),
@@ -91,6 +101,8 @@ def run() -> int:
                 print(" - Define FACEBOOK_APP_ID en el contenedor web y reinicia.")
             elif item.name == "SIGNUP_FACEBOOK":
                 print(" - Define SIGNUP_FACEBOOK con el config_id provisto por Meta.")
+            elif item.name == "WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI":
+                print(" - Define WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI con la URL de retorno aprobada en Meta.")
             elif item.name == "DEFAULT_TENANT":
                 print(" - Revisa que DEFAULT_TENANT esté configurado para resolver el tenant actual.")
             elif item.name == "Preferencia de esquema HTTPS":

--- a/templates/configuracion_signup.html
+++ b/templates/configuracion_signup.html
@@ -84,6 +84,21 @@
                 <div id="wa-phone-status" class="help" style="margin-top: 0.5rem"></div>
             </div>
             <div class="form-row" style="margin-top: 1rem;">
+                <label class="muted">Explorar datos de WhatsApp (post-signup)</label>
+                <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                    <button id="wa-accounts-refresh" class="btn-secondary" type="button">Cargar cuentas (client/owned)</button>
+                    <button id="wa-account-detail" class="btn-secondary" type="button">Detalle WABA</button>
+                    <button id="wa-templates-refresh" class="btn-secondary" type="button">Plantillas</button>
+                    <button id="wa-apps-refresh" class="btn-secondary" type="button">Apps suscritas</button>
+                    <button id="wa-app-subscribe" class="btn-primary" type="button">Suscribir app</button>
+                </div>
+                <div id="wa-insights-status" class="help" style="margin-top: 0.5rem"></div>
+                <details id="wa-insights-panel" style="margin-top: 0.5rem;">
+                    <summary class="muted">Ver datos completos de Graph API</summary>
+                    <pre id="wa-insights-debug" class="help" style="white-space: pre-wrap; margin: 0.5rem 0 0;"></pre>
+                </details>
+            </div>
+            <div class="form-row" style="margin-top: 1rem;">
                 <button id="wa-disconnect" class="btn-danger" type="button">Desconectar WhatsApp</button>
                 <div id="wa-disconnect-status" class="help" style="margin-top: 0.5rem"></div>
             </div>
@@ -322,6 +337,14 @@
     const phoneStatus = document.getElementById('wa-phone-status');
     const phoneRefresh = document.getElementById('wa-phone-refresh');
     const phoneSave = document.getElementById('wa-phone-save');
+    const accountsRefreshButton = document.getElementById('wa-accounts-refresh');
+    const accountDetailButton = document.getElementById('wa-account-detail');
+    const templatesRefreshButton = document.getElementById('wa-templates-refresh');
+    const appsRefreshButton = document.getElementById('wa-apps-refresh');
+    const appSubscribeButton = document.getElementById('wa-app-subscribe');
+    const insightsStatus = document.getElementById('wa-insights-status');
+    const insightsDebug = document.getElementById('wa-insights-debug');
+    const insightsPanel = document.getElementById('wa-insights-panel');
     const disconnectButton = document.getElementById('wa-disconnect');
     const disconnectStatus = document.getElementById('wa-disconnect-status');
 
@@ -344,6 +367,26 @@
       if (!disconnectStatus) return;
       disconnectStatus.textContent = message || '';
       disconnectStatus.style.color = isError ? '#c0392b' : '#2c3e50';
+    };
+
+    const updateInsightsStatus = (message, isError) => {
+      if (!insightsStatus) return;
+      insightsStatus.textContent = message || '';
+      insightsStatus.style.color = isError ? '#c0392b' : '#2c3e50';
+    };
+
+    const updateInsightsDebug = (label, details) => {
+      if (!insightsDebug) return;
+      const lines = [label || 'Respuesta de Graph API'];
+      if (typeof details !== 'undefined') {
+        try {
+          lines.push(JSON.stringify(details, null, 2));
+        } catch (err) {
+          lines.push(String(details));
+        }
+      }
+      insightsDebug.textContent = lines.join('\n');
+      if (insightsPanel) insightsPanel.open = true;
     };
 
     const updateDebug = (label, details) => {
@@ -463,7 +506,7 @@
       fetch(`{{ url_for('configuracion.save_signup') }}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
+        body: JSON.stringify(Object.assign({ redirect_uri: signupRedirectUri }, payload)),
       })
         .then((resp) => resp.json())
         .then((resp) => {
@@ -475,6 +518,28 @@
           }
         })
         .catch(() => updateStatus('Error al enviar los datos del signup.', true));
+    };
+
+
+    const fetchWhatsappInsights = (url, options, successLabel) => {
+      updateInsightsStatus('Consultando Graph API...');
+      fetch(url, options || {})
+        .then((resp) => resp.json())
+        .then((resp) => {
+          if (!resp.ok) {
+            updateInsightsStatus(resp.error || 'No se pudo completar la consulta.', true);
+            updateInsightsDebug('Error Graph API', resp);
+            return;
+          }
+          updateInsightsStatus(successLabel || 'Consulta completada.');
+          updateInsightsDebug(successLabel || 'Consulta completada', resp);
+          if (Array.isArray(resp.templates)) {
+            updateStatus(`Plantillas recuperadas: ${resp.templates.length}`);
+          }
+        })
+        .catch(() => {
+          updateInsightsStatus('Error de red al consultar Graph API.', true);
+        });
     };
 
     const handleFbLoginCallback = (response) => {
@@ -498,7 +563,7 @@
     };
 
     function handleSignupMessage(event) {
-      if (!event.origin || !event.origin.endsWith('facebook.com')) return;
+      if (event.origin !== 'https://www.facebook.com' && event.origin !== 'https://web.facebook.com') return;
       let data = event.data;
       if (typeof data === 'string') {
         try {
@@ -560,7 +625,34 @@
             response_type: 'code',
             override_default_response_type: true,
             extras: {
-              setup: {},
+              version: 'v3',
+              sessionInfoVersion: '3',
+              setup: {
+                business: {
+                  id: null,
+                  name: null,
+                  email: null,
+                  phone: { code: null, number: null },
+                  website: null,
+                  address: {
+                    streetAddress1: null,
+                    streetAddress2: null,
+                    city: null,
+                    state: null,
+                    zipPostal: null,
+                    country: null,
+                  },
+                  timezone: null,
+                },
+                phone: {
+                  displayName: null,
+                  category: null,
+                  description: null,
+                },
+                preVerifiedPhone: { ids: null },
+                solutionID: null,
+                whatsAppBusinessAccount: { ids: null },
+              },
             },
           },
         );
@@ -600,6 +692,41 @@
             }
           })
           .catch(() => updatePhoneStatus('Error al guardar el número.', true));
+      });
+    }
+
+
+    if (accountsRefreshButton) {
+      accountsRefreshButton.addEventListener('click', () => {
+        fetchWhatsappInsights(`{{ url_for('configuracion.whatsapp_accounts') }}`, { method: 'GET' }, 'Cuentas de WhatsApp cargadas.');
+      });
+    }
+
+    if (accountDetailButton) {
+      accountDetailButton.addEventListener('click', () => {
+        fetchWhatsappInsights(`{{ url_for('configuracion.whatsapp_account_details') }}`, { method: 'GET' }, 'Detalle de cuenta WABA cargado.');
+      });
+    }
+
+    if (templatesRefreshButton) {
+      templatesRefreshButton.addEventListener('click', () => {
+        fetchWhatsappInsights(`{{ url_for('configuracion.whatsapp_message_templates') }}`, { method: 'GET' }, 'Plantillas de mensajes cargadas.');
+      });
+    }
+
+    if (appsRefreshButton) {
+      appsRefreshButton.addEventListener('click', () => {
+        fetchWhatsappInsights(`{{ url_for('configuracion.whatsapp_subscribed_apps') }}`, { method: 'GET' }, 'Apps suscritas cargadas.');
+      });
+    }
+
+    if (appSubscribeButton) {
+      appSubscribeButton.addEventListener('click', () => {
+        fetchWhatsappInsights(`{{ url_for('configuracion.whatsapp_subscribe_app') }}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }, 'App suscrita correctamente.');
       });
     }
 
@@ -1107,6 +1234,41 @@
         trigger.disabled = false;
       }
     });
+
+
+    if (accountsRefreshButton) {
+      accountsRefreshButton.addEventListener('click', () => {
+        fetchWhatsappInsights(`{{ url_for('configuracion.whatsapp_accounts') }}`, { method: 'GET' }, 'Cuentas de WhatsApp cargadas.');
+      });
+    }
+
+    if (accountDetailButton) {
+      accountDetailButton.addEventListener('click', () => {
+        fetchWhatsappInsights(`{{ url_for('configuracion.whatsapp_account_details') }}`, { method: 'GET' }, 'Detalle de cuenta WABA cargado.');
+      });
+    }
+
+    if (templatesRefreshButton) {
+      templatesRefreshButton.addEventListener('click', () => {
+        fetchWhatsappInsights(`{{ url_for('configuracion.whatsapp_message_templates') }}`, { method: 'GET' }, 'Plantillas de mensajes cargadas.');
+      });
+    }
+
+    if (appsRefreshButton) {
+      appsRefreshButton.addEventListener('click', () => {
+        fetchWhatsappInsights(`{{ url_for('configuracion.whatsapp_subscribed_apps') }}`, { method: 'GET' }, 'Apps suscritas cargadas.');
+      });
+    }
+
+    if (appSubscribeButton) {
+      appSubscribeButton.addEventListener('click', () => {
+        fetchWhatsappInsights(`{{ url_for('configuracion.whatsapp_subscribe_app') }}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        }, 'App suscrita correctamente.');
+      });
+    }
 
     if (disconnectButton) {
       disconnectButton.addEventListener('click', () => {

--- a/tests/test_embedded_signup_redirect_uri.py
+++ b/tests/test_embedded_signup_redirect_uri.py
@@ -8,7 +8,20 @@ if str(ROOT_DIR) not in sys.path:
 from routes import configuracion
 
 
+
+def test_embedded_redirect_uri_uses_whatsapp_embedded_setting(monkeypatch):
+    monkeypatch.setattr(configuracion.Config, "WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI", "https://embedded-wa.example/callback")
+    monkeypatch.setattr(configuracion.Config, "WHATSAPP_OAUTH_REDIRECT_URI", "https://wa.example/callback")
+    monkeypatch.setattr(configuracion.Config, "EMBEDDED_SIGNUP_REDIRECT_URI", "https://legacy.example/callback")
+    monkeypatch.setattr(configuracion.Config, "SIGNUP_FACEBOOK", "https://facebook.com/dialog/oauth?redirect_uri=https%3A%2F%2Fquery.example%2Fcb")
+    monkeypatch.setattr(configuracion.Config, "PUBLIC_BASE_URL", "https://base.example")
+
+    resolved = configuracion._resolve_embedded_signup_redirect_uri("https://fallback.example/configuracion/signup")
+
+    assert resolved == "https://embedded-wa.example/callback"
+
 def test_embedded_redirect_uri_uses_whatsapp_oauth_setting(monkeypatch):
+    monkeypatch.setattr(configuracion.Config, "WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI", "")
     monkeypatch.setattr(configuracion.Config, "WHATSAPP_OAUTH_REDIRECT_URI", "https://wa.example/callback")
     monkeypatch.setattr(configuracion.Config, "EMBEDDED_SIGNUP_REDIRECT_URI", "https://embedded.example/callback")
     monkeypatch.setattr(configuracion.Config, "SIGNUP_FACEBOOK", "https://facebook.com/dialog/oauth?redirect_uri=https%3A%2F%2Fquery.example%2Fcb")
@@ -20,6 +33,7 @@ def test_embedded_redirect_uri_uses_whatsapp_oauth_setting(monkeypatch):
 
 
 def test_embedded_redirect_uri_uses_explicit_setting(monkeypatch):
+    monkeypatch.setattr(configuracion.Config, "WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI", "")
     monkeypatch.setattr(configuracion.Config, "WHATSAPP_OAUTH_REDIRECT_URI", "")
     monkeypatch.setattr(configuracion.Config, "EMBEDDED_SIGNUP_REDIRECT_URI", "https://explicit.example/callback")
     monkeypatch.setattr(configuracion.Config, "SIGNUP_FACEBOOK", "https://facebook.com/dialog/oauth?redirect_uri=https%3A%2F%2Fquery.example%2Fcb")
@@ -31,6 +45,7 @@ def test_embedded_redirect_uri_uses_explicit_setting(monkeypatch):
 
 
 def test_embedded_redirect_uri_falls_back_to_signup_url_redirect(monkeypatch):
+    monkeypatch.setattr(configuracion.Config, "WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI", "")
     monkeypatch.setattr(configuracion.Config, "WHATSAPP_OAUTH_REDIRECT_URI", "")
     monkeypatch.setattr(configuracion.Config, "EMBEDDED_SIGNUP_REDIRECT_URI", "")
     monkeypatch.setattr(
@@ -46,6 +61,7 @@ def test_embedded_redirect_uri_falls_back_to_signup_url_redirect(monkeypatch):
 
 
 def test_embedded_redirect_uri_uses_public_base_when_signup_url_has_no_redirect(monkeypatch):
+    monkeypatch.setattr(configuracion.Config, "WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI", "")
     monkeypatch.setattr(configuracion.Config, "WHATSAPP_OAUTH_REDIRECT_URI", "")
     monkeypatch.setattr(configuracion.Config, "EMBEDDED_SIGNUP_REDIRECT_URI", "")
     monkeypatch.setattr(configuracion.Config, "SIGNUP_FACEBOOK", "https://www.facebook.com/v24.0/dialog/oauth?client_id=123")

--- a/tests/test_whatsapp_signup_insights_routes.py
+++ b/tests/test_whatsapp_signup_insights_routes.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app import create_app
+from routes import configuracion
+
+
+def _admin_client(app):
+    client = app.test_client()
+    with client.session_transaction() as session:
+        session["user"] = "admin"
+        session["roles"] = ["admin"]
+    return client
+
+
+def test_whatsapp_accounts_returns_client_and_owned(monkeypatch):
+    app = create_app()
+    app.config["TESTING"] = True
+
+    tenant = SimpleNamespace(tenant_key="acme", metadata={})
+
+    monkeypatch.setattr(configuracion, "_resolve_signup_tenant", lambda: tenant)
+    monkeypatch.setattr(
+        configuracion.tenants,
+        "get_tenant_env",
+        lambda _tenant: {"META_TOKEN": "token", "BUSINESS_ID": "biz-123"},
+    )
+
+    def fake_graph_get(path, access_token, params=None):
+        assert access_token == "token"
+        if path.endswith("client_whatsapp_business_accounts"):
+            return {"ok": True, "data": {"data": [{"id": "waba-client-1"}]}}
+        if path.endswith("owned_whatsapp_business_accounts"):
+            return {"ok": True, "data": {"data": [{"id": "waba-owned-1"}]}}
+        return {"ok": False, "error": "unexpected"}
+
+    monkeypatch.setattr(configuracion, "_graph_get", fake_graph_get)
+
+    client = _admin_client(app)
+    response = client.get("/configuracion/whatsapp/accounts")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["ok"] is True
+    assert payload["business_id"] == "biz-123"
+    assert payload["client_accounts"][0]["id"] == "waba-client-1"
+    assert payload["owned_accounts"][0]["id"] == "waba-owned-1"
+
+
+def test_whatsapp_message_templates_uses_tenant_waba(monkeypatch):
+    app = create_app()
+    app.config["TESTING"] = True
+
+    tenant = SimpleNamespace(tenant_key="acme", metadata={})
+
+    monkeypatch.setattr(configuracion, "_resolve_signup_tenant", lambda: tenant)
+    monkeypatch.setattr(
+        configuracion.tenants,
+        "get_tenant_env",
+        lambda _tenant: {"META_TOKEN": "token", "WABA_ID": "waba-123"},
+    )
+
+    calls = {}
+
+    def fake_graph_get(path, access_token, params=None):
+        calls["path"] = path
+        calls["params"] = params
+        return {"ok": True, "data": {"data": [{"name": "welcome_template"}]}}
+
+    monkeypatch.setattr(configuracion, "_graph_get", fake_graph_get)
+
+    client = _admin_client(app)
+    response = client.get("/configuracion/whatsapp/message-templates")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["ok"] is True
+    assert calls["path"] == "waba-123/message_templates"
+    assert payload["templates"][0]["name"] == "welcome_template"
+
+
+def test_whatsapp_subscribe_app_calls_graph_post(monkeypatch):
+    app = create_app()
+    app.config["TESTING"] = True
+
+    tenant = SimpleNamespace(tenant_key="acme", metadata={})
+
+    monkeypatch.setattr(configuracion, "_resolve_signup_tenant", lambda: tenant)
+    monkeypatch.setattr(
+        configuracion.tenants,
+        "get_tenant_env",
+        lambda _tenant: {"META_TOKEN": "token", "WABA_ID": "waba-123"},
+    )
+
+    calls = {}
+
+    def fake_graph_post(path, access_token, data=None):
+        calls["path"] = path
+        calls["access_token"] = access_token
+        return {"ok": True, "data": {"success": True}}
+
+    monkeypatch.setattr(configuracion, "_graph_post", fake_graph_post)
+
+    client = _admin_client(app)
+    response = client.post("/configuracion/whatsapp/subscribe-app", json={})
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["ok"] is True
+    assert calls["path"] == "waba-123/subscribed_apps"
+    assert calls["access_token"] == "token"


### PR DESCRIPTION
### Motivation
- Permitir desde la misma pestaña de signup la recuperación de información de cuentas WhatsApp Business y recursos relacionados tras completar el Embedded Signup. 
- Evitar duplicación de lógica y unificar llamadas a Graph API con manejo consistente de errores y timeouts.

### Description
- Añadidos helpers reutilizables ` _graph_get` y `_graph_post` y la función `_resolve_whatsapp_token_and_business_id` para normalizar llamadas a la Graph API y resolución de credenciales. 
- Nuevos endpoints bajo `/configuracion/whatsapp/*`: `GET /accounts`, `GET /account-details`, `GET /message-templates`, `GET /subscribed-apps` y `POST /subscribe-app` para listar cuentas (client/owned), detalle WABA, plantillas y apps suscritas. 
- Extensión de la UI en `templates/configuracion_signup.html` para incluir botones rápidos, panel de depuración y los controladores JS que llaman a los nuevos endpoints desde la tarjeta de WhatsApp. 
- Config y scripts actualizados para soportar `WHATSAPP_EMBEDDED_SIGNUP_REDIRECT_URI` y advertencias en `scripts/check_embedded_signup.py`, y se actualizó `README.md` con la nota relacionada. 
- Se agregaron tests `tests/test_whatsapp_signup_insights_routes.py` y ajustes en `tests/test_embedded_signup_redirect_uri.py` que cubren los nuevos endpoints y la resolución de redirect URI.

### Testing
- Ejecutado `pytest -q tests/test_whatsapp_signup_insights_routes.py tests/test_embedded_signup_redirect_uri.py tests/test_embedded_signup_exchange.py` — todas las pruebas pasaron: `17 passed`.
- Compilación estática con `python -m py_compile routes/configuracion.py scripts/check_embedded_signup.py config.py tests/test_whatsapp_signup_insights_routes.py` — sin errores.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bb007614c8323830f76f845ebf715)