### PR TITLE
Implementar suscripciones por empresa y bloqueo por impago

### DIFF
--- a/app.py
+++ b/app.py
@@ -208,6 +208,32 @@ def create_app():
         tenants.set_current_tenant(tenant)
         tenants.set_current_tenant_env(tenants.get_tenant_env(tenant))
 
+
+    @app.before_request
+    def enforce_subscription_access():
+        endpoint = request.endpoint or ""
+        if endpoint.startswith("static"):
+            return
+        if endpoint.startswith("auth."):
+            return
+        if endpoint.startswith("tenant_admin."):
+            return
+        if endpoint.startswith("landing."):
+            return
+        if endpoint.startswith("webhook."):
+            return
+
+        tenant = tenants.get_current_tenant()
+        if not tenant:
+            return
+
+        roles = set(session.get("roles", []) or [])
+        if "superadmin" in roles:
+            return
+
+        if not tenants.is_tenant_subscription_active(tenant):
+            abort(403, description="Membresía vencida. Renueva el pago para acceder.")
+
     @app.teardown_request
     def clear_tenant_context(exc):
         tenants.clear_current_tenant()

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -7,6 +7,7 @@ from typing import Optional
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from config import Config
+from services import tenants
 from services.db import get_connection, get_roles_by_user
 
 auth_bp = Blueprint('auth', __name__)
@@ -154,13 +155,26 @@ def login():
             user_source_allows_tenant_context = True
 
         if user and _verify_password(user[2], password):
-            _clear_failed_attempts(security_key)
-            session.permanent = False
-            session['user'] = user[1]
-
             roles = get_roles_by_user(
                 user[0], allow_tenant_context=user_source_allows_tenant_context
             ) or []
+            role_keywords = set(roles)
+            tenant = tenants.get_current_tenant()
+            if tenant and 'superadmin' not in role_keywords and not tenants.is_tenant_subscription_active(tenant):
+                error = (
+                    'Tu membresía está vencida. Contacta al administrador para renovar el pago.'
+                )
+                return render_template(
+                    'login.html',
+                    error=error,
+                    success=success_message,
+                    change_error=change_error,
+                    show_change=show_change,
+                ), 403
+
+            _clear_failed_attempts(security_key)
+            session.permanent = False
+            session['user'] = user[1]
             session['roles'] = roles
             session['rol'] = roles[0] if roles else None
 

--- a/routes/tenant_admin_routes.py
+++ b/routes/tenant_admin_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import date
 from flask import Blueprint, abort, redirect, render_template, request, session, url_for
 
 from config import Config
@@ -63,6 +64,9 @@ def dashboard():
     tenant_roles = tenants.get_tenant_roles(selected_tenant) if selected_tenant else []
     tenant_users = tenants.list_tenant_users(selected_tenant) if selected_tenant else []
     tenant_env = tenants.get_tenant_env(selected_tenant) if selected_tenant else {}
+    tenant_subscription = (
+        tenants.ensure_monthly_counter_current(selected_tenant) if selected_tenant else {}
+    )
 
     message = request.args.get("msg")
     error = request.args.get("error")
@@ -74,10 +78,70 @@ def dashboard():
         tenant_roles=tenant_roles,
         tenant_users=tenant_users,
         tenant_env=tenant_env,
+        tenant_subscription=tenant_subscription,
         signup_config_code=Config.SIGNUP_FACEBOOK,
         facebook_app_id=Config.FACEBOOK_APP_ID,
         message=message,
         error=error,
+    )
+
+
+@tenant_admin_bp.route("/<tenant_key>/subscription", methods=["POST"])
+def update_tenant_subscription(tenant_key: str):
+    tenant = tenants.get_tenant(tenant_key)
+    if not tenant:
+        abort(404)
+
+    paid_until_raw = (request.form.get("paid_until") or "").strip()
+    monthly_limit_raw = (request.form.get("monthly_limit") or "").strip()
+
+    if paid_until_raw:
+        try:
+            date.fromisoformat(paid_until_raw)
+        except ValueError:
+            return redirect(
+                url_for(
+                    "tenant_admin.dashboard",
+                    tenant=tenant_key,
+                    error="La fecha de pago debe tener formato YYYY-MM-DD.",
+                )
+            )
+
+    monthly_limit = None
+    if monthly_limit_raw:
+        try:
+            monthly_limit = int(monthly_limit_raw)
+        except ValueError:
+            return redirect(
+                url_for(
+                    "tenant_admin.dashboard",
+                    tenant=tenant_key,
+                    error="El límite mensual debe ser un número entero.",
+                )
+            )
+        if monthly_limit < 0:
+            return redirect(
+                url_for(
+                    "tenant_admin.dashboard",
+                    tenant=tenant_key,
+                    error="El límite mensual no puede ser negativo.",
+                )
+            )
+
+    tenants.update_tenant_subscription(
+        tenant_key,
+        {
+            "paid_until": paid_until_raw or None,
+            "monthly_limit": monthly_limit,
+        },
+    )
+
+    return redirect(
+        url_for(
+            "tenant_admin.dashboard",
+            tenant=tenant_key,
+            msg="Suscripción actualizada correctamente.",
+        )
     )
 
 

--- a/services/tenants.py
+++ b/services/tenants.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import posixpath
+from datetime import date
 from dataclasses import dataclass
 from typing import Dict, List, Mapping
 from flask import Request
@@ -430,6 +431,68 @@ def update_tenant_env(tenant_key: str, env_updates: Mapping | None) -> TenantInf
     updated_tenant = update_tenant_metadata(tenant_key, metadata)
     _trigger_page_backfill_if_needed(previous_env, updated_tenant)
     return updated_tenant
+
+
+def _current_billing_cycle(reference_date: date | None = None) -> str:
+    current = reference_date or date.today()
+    return current.strftime("%Y-%m")
+
+
+def get_tenant_subscription(tenant: TenantInfo | None) -> dict:
+    metadata = tenant.metadata if tenant and isinstance(tenant.metadata, dict) else {}
+    subscription = metadata.get("subscription") if isinstance(metadata.get("subscription"), dict) else {}
+    normalized = dict(subscription or {})
+    normalized.setdefault("monthly_counter", 0)
+    normalized.setdefault("monthly_limit", None)
+    normalized.setdefault("billing_cycle", _current_billing_cycle())
+    normalized.setdefault("paid_until", None)
+    return normalized
+
+
+def ensure_monthly_counter_current(tenant: TenantInfo | None, *, reference_date: date | None = None) -> dict:
+    if not tenant:
+        return get_tenant_subscription(None)
+
+    current_cycle = _current_billing_cycle(reference_date)
+    subscription = get_tenant_subscription(tenant)
+    if subscription.get("billing_cycle") == current_cycle:
+        return subscription
+
+    subscription["billing_cycle"] = current_cycle
+    subscription["monthly_counter"] = 0
+    updated = update_tenant_subscription(tenant.tenant_key, subscription)
+    return get_tenant_subscription(updated)
+
+
+def update_tenant_subscription(tenant_key: str, subscription_updates: Mapping | None) -> TenantInfo:
+    tenant = get_tenant(tenant_key)
+    if not tenant:
+        raise TenantNotFoundError(f"No se encontró la empresa '{tenant_key}'.")
+
+    subscription = get_tenant_subscription(tenant)
+    if subscription_updates:
+        subscription.update(dict(subscription_updates))
+
+    metadata = dict(tenant.metadata or {})
+    metadata["subscription"] = subscription
+    return update_tenant_metadata(tenant_key, metadata)
+
+
+def is_tenant_subscription_active(tenant: TenantInfo | None, *, reference_date: date | None = None) -> bool:
+    if not tenant:
+        return True
+
+    subscription = get_tenant_subscription(tenant)
+    paid_until_raw = (subscription.get("paid_until") or "").strip() if subscription.get("paid_until") else ""
+    if not paid_until_raw:
+        return False
+
+    try:
+        paid_until = date.fromisoformat(paid_until_raw)
+    except ValueError:
+        return False
+
+    return paid_until >= (reference_date or date.today())
 
 
 def _normalize_platform(value: str | None) -> str | None:
@@ -931,6 +994,10 @@ __all__ = [
     "update_tenant_metadata",
     "create_or_update_tenant_user",
     "get_runtime_setting",
+    "is_tenant_subscription_active",
+    "update_tenant_subscription",
+    "ensure_monthly_counter_current",
+    "get_tenant_subscription",
     "TENANT_ENV_KEYS",
     "delete_tenant",
 ]

--- a/templates/admin_tenants.html
+++ b/templates/admin_tenants.html
@@ -88,9 +88,25 @@
       <div><strong>DB:</strong> {{ selected_tenant.db_name }} en {{ selected_tenant.db_host }}:{{ selected_tenant.db_port }}</div>
       <div><strong>Usuario BD:</strong> {{ selected_tenant.db_user }}</div>
       <div><strong>Metadata:</strong> {{ selected_tenant.metadata or '{}' }}</div>
+      <div><strong>Estado membresía:</strong> {% if tenant_subscription.get('paid_until') %}Activa hasta {{ tenant_subscription.get('paid_until') }}{% else %}Sin pago registrado{% endif %}</div>
+      <div><strong>Ciclo actual:</strong> {{ tenant_subscription.get('billing_cycle') }}</div>
+      <div><strong>Contador mensual:</strong> {{ tenant_subscription.get('monthly_counter', 0) }}</div>
     </div>
 
     <div class="admin-grid">
+      <div>
+        <h3>Suscripción</h3>
+        <form method="post" action="{{ url_for('tenant_admin.update_tenant_subscription', tenant_key=selected_tenant.tenant_key) }}" class="form-grid">
+          <label>Pagado hasta
+            <input type="date" name="paid_until" value="{{ tenant_subscription.get('paid_until') or '' }}" />
+          </label>
+          <label>Límite mensual (opcional)
+            <input type="number" min="0" name="monthly_limit" value="{{ tenant_subscription.get('monthly_limit') if tenant_subscription.get('monthly_limit') is not none else '' }}" placeholder="Sin límite" />
+          </label>
+          <p class="help">Si no hay fecha de pago o ya venció, los usuarios de la empresa no podrán entrar.</p>
+          <button type="submit" class="btn primary">Guardar suscripción</button>
+        </form>
+      </div>
       <div>
         <h3>Usuarios y roles</h3>
         <table class="table">

--- a/tests/test_tenant_subscriptions.py
+++ b/tests/test_tenant_subscriptions.py
@@ -1,0 +1,116 @@
+import os
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+os.environ.setdefault("INIT_DB_ON_START", "0")
+
+from app import create_app
+from routes import auth_routes, tenant_admin_routes
+from services import tenants
+
+
+class _Cursor:
+    def __init__(self, row):
+        self._row = row
+
+    def execute(self, _query, _params):
+        return None
+
+    def fetchone(self):
+        return self._row
+
+
+class _Connection:
+    def __init__(self, row):
+        self._row = row
+
+    def cursor(self):
+        return _Cursor(self._row)
+
+    def close(self):
+        return None
+
+
+def _tenant(subscription=None):
+    return tenants.TenantInfo(
+        tenant_key="acme",
+        name="Acme",
+        db_name="acme_db",
+        db_host="localhost",
+        db_port=3306,
+        db_user="root",
+        db_password="secret",
+        metadata={"subscription": subscription or {}},
+    )
+
+
+def test_is_tenant_subscription_active_validates_paid_until():
+    active = _tenant({"paid_until": "2999-12-31"})
+    expired = _tenant({"paid_until": "2000-01-01"})
+
+    assert tenants.is_tenant_subscription_active(active, reference_date=date(2026, 1, 1))
+    assert not tenants.is_tenant_subscription_active(expired, reference_date=date(2026, 1, 1))
+
+
+def test_ensure_monthly_counter_current_resets_counter(monkeypatch):
+    stale = _tenant({"billing_cycle": "2025-01", "monthly_counter": 99, "paid_until": "2999-01-01"})
+
+    def _fake_update(_tenant_key, updates):
+        return _tenant(updates)
+
+    monkeypatch.setattr(tenants, "update_tenant_subscription", _fake_update)
+
+    result = tenants.ensure_monthly_counter_current(stale, reference_date=date(2026, 2, 3))
+
+    assert result["billing_cycle"] == "2026-02"
+    assert result["monthly_counter"] == 0
+
+
+def test_login_blocks_non_superadmin_when_membership_expired(monkeypatch):
+    app = create_app()
+
+    monkeypatch.setattr(auth_routes, "get_connection", lambda allow_tenant_context=True: _Connection((7, "operador", "x")))
+    monkeypatch.setattr(auth_routes, "_verify_password", lambda stored, plain: True)
+    monkeypatch.setattr(auth_routes, "get_roles_by_user", lambda _uid, allow_tenant_context=True: ["agente"])
+    monkeypatch.setattr(tenants, "get_current_tenant", lambda: _tenant({"paid_until": "2000-01-01"}))
+    monkeypatch.setattr(tenants, "is_tenant_subscription_active", lambda tenant: False)
+
+    client = app.test_client()
+    response = client.post("/login", data={"username": "operador", "password": "12345678"})
+
+    assert response.status_code == 403
+    assert "membresía está vencida" in response.get_data(as_text=True)
+
+
+def test_superadmin_can_update_subscription_from_admin_panel(monkeypatch):
+    app = create_app()
+
+    tenant = _tenant({"paid_until": None, "monthly_counter": 0, "billing_cycle": "2026-01"})
+    captured = {}
+
+    monkeypatch.setattr(tenant_admin_routes.tenants, "get_tenant", lambda key, force_reload=False: tenant if key == "acme" else None)
+    monkeypatch.setattr(
+        tenant_admin_routes.tenants,
+        "update_tenant_subscription",
+        lambda tenant_key, payload: captured.update({"tenant_key": tenant_key, "payload": payload}),
+    )
+
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess["user"] = "superadmin"
+        sess["roles"] = ["superadmin"]
+
+    response = client.post(
+        "/admin/tenants/acme/subscription",
+        data={"paid_until": "2030-12-31", "monthly_limit": "1500"},
+    )
+
+    assert response.status_code == 302
+    assert captured["tenant_key"] == "acme"
+    assert captured["payload"]["paid_until"] == "2030-12-31"
+    assert captured["payload"]["monthly_limit"] == 1500


### PR DESCRIPTION
### Motivation

- Añadir un mecanismo de suscripción por empresa para permitir que el `superadmin` registre hasta cuándo pagó una empresa y limitar el acceso si la membresía está vencida.  
- Mantener un contador mensual y permitir establecer un `monthly_limit` y un `paid_until` por tenant para control de uso y facturación.  
- Exponer la gestión de la suscripción desde el panel de administración para que el `superadmin` pueda actualizar las fechas y límites fácilmente.

### Description

- Se añadieron helpers en `services/tenants.py`: `_current_billing_cycle`, `get_tenant_subscription`, `ensure_monthly_counter_current`, `update_tenant_subscription` e `is_tenant_subscription_active` para normalizar, persistir y validar el estado de la suscripción por tenant.  
- El panel de superadmin carga la suscripción y muestra `billing_cycle`, `monthly_counter` y `paid_until`, y se agregó el formulario y la ruta `POST /admin/tenants/<tenant_key>/subscription` en `routes/tenant_admin_routes.py` para actualizar `paid_until` y `monthly_limit`.  
- Se añadió control de acceso: en `routes/auth_routes.py` se bloquea el login de usuarios que no sean `superadmin` si la suscripción del tenant está vencida, y en `app.py` se agregó un `before_request` global que deniega acceso (403) a rutas internas cuando la membresía del tenant no está activa, con exclusiones para `auth`, `tenant_admin`, `landing`, `webhook` y `static`.  
- Se actualizó la lista de exports en `services/tenants.py` y se añadió el test de integración/unidad `tests/test_tenant_subscriptions.py` que cubre vigencia de pago, reseteo de contador por ciclo, bloqueo de login y actualización desde el panel.

### Testing

- Ejecuté `pytest -q tests/test_tenant_subscriptions.py tests/test_admin_tenants_template.py` y los tests relevantes finalizaron correctamente (`5 passed`).  
- Se añadió `tests/test_tenant_subscriptions.py` para cubrir los casos nuevos de suscripción y control de acceso por impago.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6e4c13c048323acf4fd239ada922f)