### PR TITLE
Detener IA tras CTA Flow y marcar chats en 'Atención'

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -1543,7 +1543,10 @@ def send_message():
     step = row[0] if row else ''
     current_state = row[2] if row and len(row) > 2 else None
     _schedule_followup_messages(numero, step)
-    next_state = 'asesor' if current_state else None
+    if tipo_respuesta == 'flow':
+        next_state = 'atencion'
+    else:
+        next_state = 'asesor' if current_state else None
     update_chat_state(numero, step, next_state)
     return jsonify({'status': 'success'}), 200
 

--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -1583,7 +1583,7 @@ def _is_ia_chat_pending(row, step: str | None = None) -> bool:
 
 
 def _is_agent_mode(row) -> bool:
-    return _extract_chat_status(row) == 'asesor'
+    return _extract_chat_status(row) in {'asesor', 'atencion'}
 
 
 def _catalog_context_for_prompt(prompt: str):

--- a/services/db.py
+++ b/services/db.py
@@ -69,6 +69,14 @@ TENANTS_TABLE_DDL = """
 
 CHAT_STATE_DEFAULTS = [
     {
+        "key": "atencion",
+        "label": "Atención",
+        "color": "#fd7e14",
+        "text_color": "#ffffff",
+        "priority": 60,
+        "visible": 1,
+    },
+    {
         "key": "esperando_respuesta",
         "label": "Esperando respuesta",
         "color": "#f0ad4e",

--- a/static/style.css
+++ b/static/style.css
@@ -334,6 +334,7 @@
     .estado-sin_respuesta { background-color: #ff4d4f; color: var(--text-light); }
     .estado-espera_usuario { background-color: #ffc107; color: var(--text-main); }
     .estado-asesor { background-color: #28a745; color: var(--text-light); }
+    .estado-atencion { background-color: #fd7e14; color: var(--text-light); }
     .state-color-dot {
       display: inline-block;
       width: 10px;

--- a/tests/test_send_message_flow_state.py
+++ b/tests/test_send_message_flow_state.py
@@ -1,0 +1,85 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+os.environ.setdefault("INIT_DB_ON_START", "0")
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from app import create_app
+from routes import chat_routes
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_send_message_flow_sets_attention_state(client, monkeypatch):
+    update_calls = []
+
+    monkeypatch.setattr(chat_routes, "enviar_mensaje", lambda *_, **__: (True, None))
+    monkeypatch.setattr(
+        chat_routes,
+        "obtener_ultimo_mensaje_cliente_info",
+        lambda *_: {"tipo": "cliente", "timestamp": None},
+    )
+    monkeypatch.setattr(chat_routes, "_schedule_followup_messages", lambda *_, **__: None)
+    monkeypatch.setattr(chat_routes, "get_chat_state", lambda *_: ("ia_chat", None, "en_flujo"))
+    monkeypatch.setattr(chat_routes, "update_chat_state", lambda *args, **kwargs: update_calls.append((args, kwargs)))
+
+    with client.session_transaction() as sess:
+        sess["user"] = "tester"
+        sess["rol"] = "admin"
+
+    response = client.post(
+        "/send_message",
+        json={
+            "numero": "573001112233",
+            "mensaje": "Completa este formulario",
+            "tipo_respuesta": "flow",
+            "opciones": {"flow_cta": "Abrir demo", "flow_id": "123"},
+        },
+    )
+
+    assert response.status_code == 200
+    assert update_calls
+    assert update_calls[-1][0] == ("573001112233", "ia_chat", "atencion")
+
+
+def test_send_message_text_keeps_agent_state(client, monkeypatch):
+    update_calls = []
+
+    monkeypatch.setattr(chat_routes, "enviar_mensaje", lambda *_, **__: (True, None))
+    monkeypatch.setattr(
+        chat_routes,
+        "obtener_ultimo_mensaje_cliente_info",
+        lambda *_: {"tipo": "cliente", "timestamp": None},
+    )
+    monkeypatch.setattr(chat_routes, "_schedule_followup_messages", lambda *_, **__: None)
+    monkeypatch.setattr(chat_routes, "get_chat_state", lambda *_: ("ia_chat", None, "en_flujo"))
+    monkeypatch.setattr(chat_routes, "update_chat_state", lambda *args, **kwargs: update_calls.append((args, kwargs)))
+
+    with client.session_transaction() as sess:
+        sess["user"] = "tester"
+        sess["rol"] = "admin"
+
+    response = client.post(
+        "/send_message",
+        json={
+            "numero": "573001112233",
+            "mensaje": "Mensaje normal",
+            "tipo_respuesta": "texto",
+        },
+    )
+
+    assert response.status_code == 200
+    assert update_calls
+    assert update_calls[-1][0] == ("573001112233", "ia_chat", "asesor")

--- a/tests/test_step_guards.py
+++ b/tests/test_step_guards.py
@@ -288,6 +288,10 @@ def test_handle_text_message_delays_ia_chat(monkeypatch):
     assert update_calls[-1] == ("ia_chat", "espera_usuario")
 
 
+def test_is_agent_mode_accepts_attention_status():
+    assert webhook_module._is_agent_mode(("ia_chat", datetime.now(), "atencion")) is True
+
+
 def test_is_schedule_active_honors_overnight_ranges():
     tzinfo = ZoneInfo("America/Bogota")
     hours = "17:30-07:30"


### PR DESCRIPTION
### Motivation
- Evitar que la IA siga respondiendo automáticamente después de que se envíe un llamado a la acción (Flow) y que un asesor pueda tomar la conversación manualmente identificando claramente esos chats. 

### Description
- Se añadió el nuevo estado por defecto `atencion` (label `Atención`, color `#fd7e14`) en `services/db.py` para registrarlo en las definiciones de estados. 
- En `routes/chat_routes.py` se cambió la lógica de `POST /send_message` para que cuando `tipo_respuesta == 'flow'` el chat pase a `atencion` en lugar de `asesor`. 
- En `routes/webhook.py` se amplió `_is_agent_mode` para tratar `atencion` como modo asesor y así bloquear las respuestas automáticas/IA cuando el chat esté en ese estado. 
- Se añadió estilo UI de respaldo `.estado-atencion` en `static/style.css` y se agregaron pruebas unitarias en `tests/test_send_message_flow_state.py` y una comprobación en `tests/test_step_guards.py`. 

### Testing
- Se ejecutaron los tests añadidos: `pytest -q tests/test_send_message_flow_state.py tests/test_step_guards.py -q` y ambos pasaron (`... [100%]`). 
- Las pruebas cubren que enviar `tipo_respuesta=flow` provoca `update_chat_state(numero, step, 'atencion')` y que un mensaje de texto sigue marcando `asesor`. 
- Se añadió un test que verifica que `_is_agent_mode` considera `atencion` como modo asesor y éste también pasó en la suite ejecutada.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c54a663e6c8323a04937de1dc53559)