### PR TITLE
Agregar desactivación por chat para IA/seguimiento y bloqueo permanente tras mensaje de asesor

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -46,6 +46,10 @@ from services.db import (
     obtener_ultimo_mensaje_cliente_info,
 )
 from services.normalize_text import normalize_text
+from services.chat_automation import (
+    lock_chat_automation_due_to_advisor,
+    set_chat_automation_settings,
+)
 from routes.configuracion import _ensure_ia_config_table
 
 chat_bp = Blueprint('chat', __name__)
@@ -453,6 +457,45 @@ def _fetch_chat_states(cursor, numeros: list[str]) -> dict[str, tuple[str | None
         for row in cursor.fetchall()
         if row and row[0]
     }
+
+
+def _fetch_chat_automation_settings(cursor, numeros: list[str]) -> dict[str, dict[str, bool]]:
+    placeholders, params = _build_in_clause_params(numeros)
+    if not placeholders:
+        return {}
+    cursor.execute(
+        f"""
+        SELECT numero, ai_enabled, followup_enabled, locked_by_advisor
+          FROM chat_automation_settings
+         WHERE numero IN ({placeholders})
+        """,
+        params,
+    )
+    return {
+        row[0]: {
+            "ai_enabled": bool(row[1]),
+            "followup_enabled": bool(row[2]),
+            "locked_by_advisor": bool(row[3]),
+        }
+        for row in cursor.fetchall()
+        if row and row[0]
+    }
+
+
+def _fetch_advisor_chats(cursor, numeros: list[str]) -> set[str]:
+    placeholders, params = _build_in_clause_params(numeros)
+    if not placeholders:
+        return set()
+    cursor.execute(
+        f"""
+        SELECT DISTINCT numero
+          FROM mensajes
+         WHERE numero IN ({placeholders})
+           AND tipo LIKE 'asesor%%'
+        """,
+        params,
+    )
+    return {row[0] for row in cursor.fetchall() if row and row[0]}
 
 
 def _fetch_user_role_keywords(cursor, user_ids: list[int]) -> dict[int, list[str]]:
@@ -1154,6 +1197,52 @@ def toggle_ai_enabled():
 
     return jsonify({"ok": True, "enabled": bool(enabled)})
 
+
+@chat_bp.route('/chat_toggle_ai', methods=['POST'])
+def chat_toggle_ai():
+    if "user" not in session:
+        return jsonify({"ok": False, "error": "No autorizado"}), 401
+    payload = request.get_json(silent=True) or {}
+    numero = (payload.get("numero") or "").strip()
+    enabled_raw = payload.get("enabled")
+    enabled = str(enabled_raw).lower() in {"1", "true", "t", "yes", "on"}
+    if not numero:
+        return jsonify({"ok": False, "error": "Número requerido"}), 400
+
+    conn = get_connection()
+    c = conn.cursor()
+    try:
+        if not _require_chat_access(c, numero):
+            return jsonify({"ok": False, "error": "No autorizado"}), 403
+    finally:
+        conn.close()
+
+    status = set_chat_automation_settings(numero, ai_enabled=enabled)
+    return jsonify({"ok": True, **status})
+
+
+@chat_bp.route('/chat_toggle_followup', methods=['POST'])
+def chat_toggle_followup():
+    if "user" not in session:
+        return jsonify({"ok": False, "error": "No autorizado"}), 401
+    payload = request.get_json(silent=True) or {}
+    numero = (payload.get("numero") or "").strip()
+    enabled_raw = payload.get("enabled")
+    enabled = str(enabled_raw).lower() in {"1", "true", "t", "yes", "on"}
+    if not numero:
+        return jsonify({"ok": False, "error": "Número requerido"}), 400
+
+    conn = get_connection()
+    c = conn.cursor()
+    try:
+        if not _require_chat_access(c, numero):
+            return jsonify({"ok": False, "error": "No autorizado"}), 403
+    finally:
+        conn.close()
+
+    status = set_chat_automation_settings(numero, followup_enabled=enabled)
+    return jsonify({"ok": True, **status})
+
 @chat_bp.route('/get_chat/<numero>')
 def get_chat(numero):
     if "user" not in session:
@@ -1542,6 +1631,7 @@ def send_message():
     row = get_chat_state(numero)
     step = row[0] if row else ''
     current_state = row[2] if row and len(row) > 2 else None
+    lock_chat_automation_due_to_advisor(numero)
     _schedule_followup_messages(numero, step)
     if tipo_respuesta == 'flow':
         next_state = 'atencion'
@@ -1650,6 +1740,11 @@ def get_chat_list():
     first_client_types = _fetch_first_client_type_by_chat(c, numeros)
     roles_by_chat = _fetch_chat_roles(c, numeros)
     states_by_chat = _fetch_chat_states(c, numeros)
+    try:
+        automation_settings_by_chat = _fetch_chat_automation_settings(c, numeros)
+    except Exception:
+        automation_settings_by_chat = {}
+    advisor_chats = _fetch_advisor_chats(c, numeros)
     rules_cache: dict[str, list] = {}
     assigned_user_ids = [uid for uid, _name in assignments_by_chat.values() if uid]
     user_role_keywords = _fetch_user_role_keywords(c, assigned_user_ids)
@@ -1829,6 +1924,12 @@ def get_chat_list():
                 inicial_rol = role_keywords[0][0].upper()
 
         estado_def = chat_state_def_map.get(estado) if estado else None
+        automation_settings = automation_settings_by_chat.get(numero, {})
+        locked_by_advisor = numero in advisor_chats or bool(
+            automation_settings.get("locked_by_advisor")
+        )
+        ai_enabled = bool(automation_settings.get("ai_enabled", True)) and not locked_by_advisor
+        followup_enabled = bool(automation_settings.get("followup_enabled", True)) and not locked_by_advisor
 
         chats.append({
             "numero": numero,
@@ -1848,6 +1949,9 @@ def get_chat_list():
             "last_timestamp": last_ts,
             "last_message": ultimo,
             "first_link_url": primer_link,
+            "ai_enabled": ai_enabled,
+            "followup_enabled": followup_enabled,
+            "locked_by_advisor": locked_by_advisor,
         })
     if profiles_updated:
         conn.commit()
@@ -2161,6 +2265,8 @@ def send_image():
         return jsonify({'error': error_reason or 'No se pudo enviar la imagen.'}), 502
     row = get_chat_state(numero)
     step = row[0] if row else ''
+    if origen != 'bot':
+        lock_chat_automation_due_to_advisor(numero)
     _schedule_followup_messages(numero, step)
     if origen != 'bot':
         update_chat_state(numero, step, 'asesor')
@@ -2215,6 +2321,7 @@ def send_document():
         return jsonify({'error': error_reason or 'No se pudo enviar el documento.'}), 502
     row = get_chat_state(numero)
     step = row[0] if row else ''
+    lock_chat_automation_due_to_advisor(numero)
     _schedule_followup_messages(numero, step)
     update_chat_state(numero, step, 'asesor')
 
@@ -2454,6 +2561,8 @@ def send_audio():
         )
     row = get_chat_state(numero)
     step = row[0] if row else ''
+    if origen != 'bot':
+        lock_chat_automation_due_to_advisor(numero)
     _schedule_followup_messages(numero, step)
     if origen != 'bot':
         update_chat_state(numero, step, 'asesor')
@@ -2565,6 +2674,8 @@ def send_video():
             return jsonify({'error': error_reason or 'No se pudo enviar el video.'}), 502
     row = get_chat_state(numero)
     step = row[0] if row else ''
+    if origen != 'bot':
+        lock_chat_automation_due_to_advisor(numero)
     _schedule_followup_messages(numero, step)
     if origen != 'bot':
         update_chat_state(numero, step, 'asesor')

--- a/routes/webhook.py
+++ b/routes/webhook.py
@@ -55,6 +55,9 @@ from services.ia_client import generate_response
 from services.catalog import extract_text_from_image, find_relevant_pages
 from services.ia_client import generate_response_with_image
 from services.assignments import assign_chat_to_active_user
+from services.chat_automation import (
+    get_chat_automation_status,
+)
 
 webhook_bp = Blueprint('webhook', __name__)
 logger = logging.getLogger(__name__)
@@ -138,6 +141,26 @@ def _is_ai_enabled() -> bool:
         return True
     finally:
         conn.close()
+
+
+def _is_chat_ai_enabled(numero: str | None) -> bool:
+    if not numero:
+        return True
+    try:
+        status = get_chat_automation_status(numero)
+    except Exception:
+        return True
+    return bool(status.get("ai_enabled"))
+
+
+def _is_chat_followup_enabled(numero: str | None) -> bool:
+    if not numero:
+        return True
+    try:
+        status = get_chat_automation_status(numero)
+    except Exception:
+        return True
+    return bool(status.get("followup_enabled"))
 
 
 def _clear_followup_timers(numero: str) -> None:
@@ -695,6 +718,14 @@ def _send_followup_if_pending(
 
 
 def _schedule_followup_messages(numero: str, message_step: str) -> None:
+    if not _is_chat_followup_enabled(numero):
+        logger.info(
+            "Seguimiento desactivado para el chat; se omite programación",
+            extra={"numero": numero},
+        )
+        _clear_followup_timers(numero)
+        return
+
     with followup_lock:
         existing = [
             timer for timer in followup_timers.get(numero, [])
@@ -715,7 +746,7 @@ def _schedule_followup_messages(numero: str, message_step: str) -> None:
     message_step_norm = _normalize_step_name(message_step)
     if message_step_norm in {"ia", "ia_chat"}:
         active_hours, active_days = _get_schedule_for_step(message_step, None)
-        if not _is_ia_rule_active(active_hours, active_days):
+        if not _is_ia_rule_active(active_hours, active_days, numero=numero):
             return
     config = _get_ia_followup_config()
     if not config:
@@ -1314,8 +1345,15 @@ def _is_schedule_active(
     return False
 
 
-def _is_ia_rule_active(active_hours: str | None, active_days: str | None) -> bool:
+def _is_ia_rule_active(
+    active_hours: str | None,
+    active_days: str | None,
+    *,
+    numero: str | None = None,
+) -> bool:
     if not _is_ai_enabled():
+        return False
+    if not _is_chat_ai_enabled(numero):
         return False
     if active_hours or active_days:
         return _is_schedule_active(active_hours, active_days)
@@ -1845,6 +1883,10 @@ def _reply_with_ai_image(
     history_step: str | None = None,
     message_step: str | None = None,
 ) -> bool:
+    if not _is_chat_ai_enabled(numero):
+        logger.info("IA desactivada para el chat; se omite respuesta con imagen", extra={"numero": numero})
+        return False
+
     image_url = _normalize_media_url(media_url)
     if not image_url:
         logger.info("Sin URL de imagen para enviar a la IA", extra={"numero": numero})
@@ -1958,6 +2000,9 @@ def _reply_with_ai(
     allow_empty_catalog: bool = False,
 ) -> bool:
     """Envía el mensaje al modelo de IA y responde al usuario."""
+    if not _is_chat_ai_enabled(numero):
+        logger.info("IA desactivada para el chat; se omite respuesta", extra={"numero": numero})
+        return False
 
     prompt = (user_text or "").strip() or obtener_ultimo_mensaje_cliente(numero)
     if not prompt:
@@ -2530,7 +2575,7 @@ def handle_option_reply(numero, option_id, platform: str | None = None):
                 row[0],
                 matched_text_norm=normalize_text(option_id),
             )
-            if is_ia and not _is_ia_rule_active(row[9], row[10]):
+            if is_ia and not _is_ia_rule_active(row[9], row[10], numero=numero):
                 continue
             if _normalize_option_value((row[0] or '').strip()) == option_norm:
                 return row
@@ -2540,7 +2585,7 @@ def handle_option_reply(numero, option_id, platform: str | None = None):
                 row[0],
                 matched_text_norm=normalize_text(option_id),
             )
-            if is_ia and not _is_ia_rule_active(row[9], row[10]):
+            if is_ia and not _is_ia_rule_active(row[9], row[10], numero=numero):
                 continue
             return row
         return None
@@ -2700,7 +2745,7 @@ def dispatch_rule(
         current_step,
         matched_text_norm=matched_text_norm,
     )
-    if use_ia and not _is_ia_rule_active(active_hours, active_days):
+    if use_ia and not _is_ia_rule_active(active_hours, active_days, numero=numero):
         use_ia = False
     if use_ia and current_step_norm == "ia_chat":
         use_ia = False
@@ -2760,7 +2805,7 @@ def dispatch_rule(
         _rule_has_ia_trigger(input_text)
         and _rule_has_non_ia_inputs(input_text)
         and not _rule_input_matches_ia_trigger(matched_text_norm, input_text)
-        and _is_ia_rule_active(active_hours, active_days)
+        and _is_ia_rule_active(active_hours, active_days, numero=numero)
     )
     if should_defer_ia and not next_step:
         set_user_step(numero, "ia_chat")
@@ -2824,6 +2869,7 @@ def advance_steps(numero: str, steps_str: str, visited=None, platform: str | Non
             if _should_use_ia_for_rule(regla[7], step) and not _is_ia_rule_active(
                 active_hours,
                 active_days,
+                numero=numero,
             ):
                 set_user_step(numero, step)
                 return
@@ -2925,6 +2971,7 @@ def process_step_chain(
         if _should_use_ia_for_rule(patt, step, matched_text_norm=text_norm) and not _is_ia_rule_active(
             active_hours,
             active_days,
+            numero=numero,
         ):
             continue
         dispatch_rule(
@@ -2976,7 +3023,7 @@ def process_step_chain(
                     rule_step,
                     matched_text_norm=text_norm,
                 )
-                if is_ia and not _is_ia_rule_active(active_hours, active_days):
+                if is_ia and not _is_ia_rule_active(active_hours, active_days, numero=numero):
                     continue
                 matches.append(row)
                 continue
@@ -2986,7 +3033,7 @@ def process_step_chain(
                     rule_step,
                     matched_text_norm=text_norm,
                 )
-                if is_ia and not _is_ia_rule_active(active_hours, active_days):
+                if is_ia and not _is_ia_rule_active(active_hours, active_days, numero=numero):
                     continue
                 matches.append(row)
         if not matches:
@@ -3018,6 +3065,7 @@ def process_step_chain(
             if _should_use_ia_for_rule(r[7], step, matched_text_norm=text_norm) and not _is_ia_rule_active(
                 active_hours,
                 active_days,
+                numero=numero,
             ):
                 continue
             selected_rule = r
@@ -3208,7 +3256,7 @@ def handle_text_message(
         current_step = get_current_step(numero)
         current_step_norm = _normalize_step_name(current_step)
         _apply_role_for_step(numero, current_step, platform)
-        if not _is_ia_rule_active(*_get_schedule_for_step(current_step, platform)):
+        if not _is_ia_rule_active(*_get_schedule_for_step(current_step, platform), numero=numero):
             return
         if current_step_norm == "ia_chat":
             _reply_with_ai(

--- a/services/chat_automation.py
+++ b/services/chat_automation.py
@@ -1,0 +1,119 @@
+"""Preferencias de automatización por chat (IA y seguimiento)."""
+
+from __future__ import annotations
+
+from services.db import get_connection
+
+
+def _ensure_chat_automation_table(cursor) -> None:
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS chat_automation_settings (
+          numero VARCHAR(64) PRIMARY KEY,
+          ai_enabled TINYINT(1) NOT NULL DEFAULT 1,
+          followup_enabled TINYINT(1) NOT NULL DEFAULT 1,
+          locked_by_advisor TINYINT(1) NOT NULL DEFAULT 0,
+          updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB;
+        """
+    )
+
+
+def _chat_has_advisor_message(cursor, numero: str) -> bool:
+    cursor.execute(
+        """
+        SELECT 1
+          FROM mensajes
+         WHERE numero = %s
+           AND tipo LIKE 'asesor%%'
+         LIMIT 1
+        """,
+        (numero,),
+    )
+    return cursor.fetchone() is not None
+
+
+def get_chat_automation_status(numero: str) -> dict[str, bool]:
+    conn = get_connection()
+    c = conn.cursor()
+    try:
+        _ensure_chat_automation_table(c)
+        c.execute(
+            """
+            SELECT ai_enabled, followup_enabled, locked_by_advisor
+              FROM chat_automation_settings
+             WHERE numero = %s
+             LIMIT 1
+            """,
+            (numero,),
+        )
+        row = c.fetchone()
+        advisor_lock = _chat_has_advisor_message(c, numero)
+    finally:
+        conn.close()
+
+    ai_enabled = bool(row[0]) if row else True
+    followup_enabled = bool(row[1]) if row else True
+    locked_by_advisor = bool(row[2]) if row else False
+    if advisor_lock:
+        locked_by_advisor = True
+        ai_enabled = False
+        followup_enabled = False
+
+    return {
+        "ai_enabled": ai_enabled,
+        "followup_enabled": followup_enabled,
+        "locked_by_advisor": locked_by_advisor,
+    }
+
+
+def set_chat_automation_settings(
+    numero: str,
+    *,
+    ai_enabled: bool | None = None,
+    followup_enabled: bool | None = None,
+    locked_by_advisor: bool | None = None,
+) -> dict[str, bool]:
+    current = get_chat_automation_status(numero)
+    next_ai = current["ai_enabled"] if ai_enabled is None else bool(ai_enabled)
+    next_followup = (
+        current["followup_enabled"] if followup_enabled is None else bool(followup_enabled)
+    )
+    next_locked = (
+        current["locked_by_advisor"] if locked_by_advisor is None else bool(locked_by_advisor)
+    )
+
+    if current["locked_by_advisor"]:
+        next_locked = True
+        next_ai = False
+        next_followup = False
+
+    conn = get_connection()
+    c = conn.cursor()
+    try:
+        _ensure_chat_automation_table(c)
+        c.execute(
+            """
+            INSERT INTO chat_automation_settings (numero, ai_enabled, followup_enabled, locked_by_advisor)
+            VALUES (%s, %s, %s, %s)
+            ON DUPLICATE KEY UPDATE
+                ai_enabled = VALUES(ai_enabled),
+                followup_enabled = VALUES(followup_enabled),
+                locked_by_advisor = VALUES(locked_by_advisor)
+            """,
+            (numero, int(next_ai), int(next_followup), int(next_locked)),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return get_chat_automation_status(numero)
+
+
+def lock_chat_automation_due_to_advisor(numero: str) -> dict[str, bool]:
+    return set_chat_automation_settings(
+        numero,
+        ai_enabled=False,
+        followup_enabled=False,
+        locked_by_advisor=True,
+    )

--- a/static/style.css
+++ b/static/style.css
@@ -753,6 +753,11 @@
     .context-menu .context-option {
       display:block;
     }
+    .context-menu > div.disabled {
+      opacity: 0.6;
+      cursor: default;
+      pointer-events: none;
+    }
     .chat-context-menu {
       position:fixed;
       min-width:220px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -150,6 +150,8 @@
   <div id="contextMenu" class="context-menu"><div id="replyAction">Responder</div></div>
   <div id="chatContextMenu" class="context-menu chat-context-menu">
     <div id="chatAliasAction">Asignar alias</div>
+    <div id="chatToggleAiAction">Desactivar IA</div>
+    <div id="chatToggleFollowupAction">Desactivar seguimiento</div>
     <div id="chatFinishAction" class="danger-action">Finalizar chat</div>
     <div id="chatDeleteAction" class="danger-action">Eliminar chat</div>
     <div class="menu-divider"></div>
@@ -347,6 +349,8 @@
       const replyAction = document.getElementById('replyAction');
       const chatContextMenu = document.getElementById('chatContextMenu');
       const chatAliasAction = document.getElementById('chatAliasAction');
+      const chatToggleAiAction = document.getElementById('chatToggleAiAction');
+      const chatToggleFollowupAction = document.getElementById('chatToggleFollowupAction');
       const chatFinishAction = document.getElementById('chatFinishAction');
       const chatDeleteAction = document.getElementById('chatDeleteAction');
       const chatFinishButton = document.getElementById('chatFinishButton');
@@ -1740,6 +1744,18 @@
         setSectionExpanded(chatUsersSection, false);
         buildChatRoleOptions(chatData);
         buildChatUserOptions(chatData);
+        if (chatToggleAiAction) {
+          const aiEnabled = chatData.ai_enabled !== false;
+          chatToggleAiAction.textContent = aiEnabled ? 'Desactivar IA' : 'IA desactivada';
+          chatToggleAiAction.classList.toggle('disabled', !aiEnabled);
+        }
+        if (chatToggleFollowupAction) {
+          const followupEnabled = chatData.followup_enabled !== false;
+          chatToggleFollowupAction.textContent = followupEnabled
+            ? 'Desactivar seguimiento'
+            : 'Seguimiento desactivado';
+          chatToggleFollowupAction.classList.toggle('disabled', !followupEnabled);
+        }
       }
 
       function buildChatRoleOptions(chatData) {
@@ -1918,6 +1934,56 @@
           body: JSON.stringify({ numero: chatData.numero, nombre: trimmed })
         }).then(() => fetchChatList());
       });
+
+      function toggleChatAutomation(endpoint, numero, enabled, fallbackMessage) {
+        return fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ numero, enabled })
+        }).then(async resp => {
+          const payload = await resp.json().catch(() => ({}));
+          if (!resp.ok || payload.ok === false) {
+            throw new Error(payload.error || fallbackMessage);
+          }
+          return payload;
+        });
+      }
+
+      if (chatToggleAiAction) {
+        chatToggleAiAction.addEventListener('click', () => {
+          if (!chatContextTarget || chatToggleAiAction.classList.contains('disabled')) return;
+          const chatData = chatContextTarget;
+          hideChatContextMenu();
+          toggleChatAutomation('/chat_toggle_ai', chatData.numero, false, 'No se pudo desactivar IA')
+            .then(() => {
+              fetchChatList();
+              if (currentChat === chatData.numero) loadMessages();
+            })
+            .catch(err => {
+              console.error(err);
+              alert(err.message || 'No se pudo desactivar IA');
+            });
+        });
+      }
+
+      if (chatToggleFollowupAction) {
+        chatToggleFollowupAction.addEventListener('click', () => {
+          if (!chatContextTarget || chatToggleFollowupAction.classList.contains('disabled')) return;
+          const chatData = chatContextTarget;
+          hideChatContextMenu();
+          toggleChatAutomation(
+            '/chat_toggle_followup',
+            chatData.numero,
+            false,
+            'No se pudo desactivar seguimiento'
+          )
+            .then(() => fetchChatList())
+            .catch(err => {
+              console.error(err);
+              alert(err.message || 'No se pudo desactivar seguimiento');
+            });
+        });
+      }
 
       function resetActiveChatIfMatches(numero) {
         if (currentChat !== numero) return;


### PR DESCRIPTION
### Motivation
- Evitar que la IA y los mensajes de seguimiento sigan enviándose a un chat después de que un asesor haya intervenido, y exponer en la UI controles por chat para desactivar manualmente IA y seguimiento.
- Registrar y respetar la preferencia por chat (y un bloqueo irreversible cuando ya exista al menos un mensaje de tipo `asesor`) para que la automatización no se reactive accidentalmente.

### Description
- Añadido `services/chat_automation.py` para persistir y consultar las preferencias por chat: `ai_enabled`, `followup_enabled` y `locked_by_advisor`, con función `lock_chat_automation_due_to_advisor` que marca bloqueo permanente. (nuevo archivo `services/chat_automation.py`)
- Backend (API): agregados endpoints `POST /chat_toggle_ai` y `POST /chat_toggle_followup` que validan sesión/acceso y actualizan la configuración por chat; la información por chat (`ai_enabled`, `followup_enabled`, `locked_by_advisor`) se incluye en la respuesta de `GET /get_chat_list`. (modificaciones en `routes/chat_routes.py`)
- Bloqueo al intervenir asesor: al enviar mensajes desde la interfaz como `asesor` (texto, imagen, documento, audio, video) se invoca `lock_chat_automation_due_to_advisor(numero)` para desactivar IA y seguimiento permanentemente para ese chat. (modificaciones en `routes/chat_routes.py`)
- Integración con la lógica de reglas/IA/seguimiento en `webhook`: añadidas funciones `_is_chat_ai_enabled` y `_is_chat_followup_enabled`; `_schedule_followup_messages` abandona la programación si el seguimiento está desactivado; las rutas de decisión de IA respetan la desactivación por chat y `_is_ia_rule_active` ahora recibe `numero` para verificar el flag por chat. También se evita contestar con IA si está desactivada. (modificaciones en `routes/webhook.py`)
- UI: en `templates/index.html` se añadieron acciones contextuales por chat en el menú (`Desactivar IA`, `Desactivar seguimiento`) que llaman a los nuevos endpoints y muestran estado/deshabilitan visualmente si ya está inactivo; se agregó `toggleChatAutomation` en JS. (modificaciones en `templates/index.html`)
- Estilos: añadido estilo para opciones de menú contextual en estado deshabilitado. (modificación en `static/style.css`)
- Garantía: la lógica impide reactivar IA/seguimiento en un chat que quedó marcado como `locked_by_advisor` (comportamiento "para siempre").

### Testing
- Se compiló el código Python modificado con `python -m py_compile routes/chat_routes.py routes/webhook.py services/chat_automation.py`, y la compilación fue exitosa. (sintaxis OK)
- Se ejecutaron tests unitarios limitados con `pytest -q tests/test_session_closure.py tests/test_delete_chat_route.py`; resultado: 7 tests pasaron y 1 falló (falla `test_finalizar_chat_envia_notificacion`, el endpoint devolvió `403` en lugar de `200`).
- Nota sobre el fallo: la suite mostró una diferencia de autorización/estado en `finalizar_chat` en el test citado; el resto de pruebas ejecutadas pasaron correctamente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c550a7274c8323906a727cc690ab57)