### PR TITLE
Oculta superadmin en listado de usuarios

### DIFF
--- a/routes/users_routes.py
+++ b/routes/users_routes.py
@@ -101,6 +101,7 @@ def manage_users():
               FROM usuarios u
          LEFT JOIN user_roles ur ON u.id = ur.user_id
          LEFT JOIN roles r ON ur.role_id = r.id
+             WHERE LOWER(u.username) <> 'superadmin'
           GROUP BY u.id, u.username, u.nombre
           ORDER BY u.username
             '''

--- a/tests/test_users_routes.py
+++ b/tests/test_users_routes.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+import sys
+
+from flask import Blueprint, Flask
+
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from routes import users_routes
+
+
+class _FakeCursor:
+    def __init__(self):
+        self.queries = []
+        self._fetchall_calls = 0
+
+    def execute(self, query, params=None):
+        self.queries.append((" ".join(query.split()), params))
+
+    def fetchall(self):
+        self._fetchall_calls += 1
+        if self._fetchall_calls == 1:
+            return [(1, "Administrador")]
+        return [
+            (2, "agente", "Agente", "Administrador"),
+        ]
+
+
+class _FakeConnection:
+    def __init__(self):
+        self.cursor_instance = _FakeCursor()
+        self.closed = False
+
+    def cursor(self):
+        return self.cursor_instance
+
+    def close(self):
+        self.closed = True
+
+
+def _app_with_admin_session():
+    app = Flask(__name__, template_folder=str(ROOT_DIR / "templates"))
+    app.secret_key = "test"
+    chat_bp = Blueprint("chat", __name__)
+
+    @chat_bp.route("/")
+    def index():
+        return "ok"
+
+    app.register_blueprint(chat_bp)
+    app.register_blueprint(users_routes.users_bp)
+
+    @app.before_request
+    def _fake_login():
+        from flask import session
+
+        session["user"] = "admin"
+        session["roles"] = ["admin"]
+
+    return app
+
+
+def test_manage_users_excludes_superadmin_from_listing(monkeypatch):
+    app = _app_with_admin_session()
+    fake_conn = _FakeConnection()
+    monkeypatch.setattr(users_routes, "get_connection", lambda: fake_conn)
+
+    with app.test_client() as client:
+        response = client.get("/usuarios")
+
+    assert response.status_code == 200
+    body = response.get_data(as_text=True)
+    assert "agente" in body
+    assert "superadmin" not in body
+
+    users_query = fake_conn.cursor_instance.queries[-1][0]
+    assert "WHERE LOWER(u.username) <> 'superadmin'" in users_query


### PR DESCRIPTION
### Motivation
- Mantener la interfaz de administración limpia evitando que el usuario especial `superadmin` aparezca en la lista pública de usuarios de la ruta `/usuarios`.
- Asegurar que la vista y la consulta SQL no muestren ni permitan actuar sobre ese usuario desde la UI normal.

### Description
- Se añadió un filtro SQL en `routes/users_routes.py` para excluir explícitamente a `superadmin` usando `WHERE LOWER(u.username) <> 'superadmin'` en la consulta que obtiene los usuarios listados. 
- No se modificó la template `templates/usuarios.html`; la exclusión se realiza en la capa de datos para mantener comportamiento consistente en todas las vistas que reutilicen la consulta.
- Se agregó `tests/test_users_routes.py` con una prueba que simula la conexión a la base de datos y verifica que la respuesta HTML no contiene `superadmin` y que la consulta ejecutada incluye el filtro esperado.

### Testing
- Se ejecutó la prueba unitaria `pytest -q tests/test_users_routes.py` y pasó correctamente (`1 passed`).
- La prueba valida que la ruta `/usuarios` responde con `200`, que el HTML contiene usuarios regulares y no `superadmin`, y que la consulta SQL contiene `WHERE LOWER(u.username) <> 'superadmin'`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c69a85584c8323b18ef86b2bcdbd3e)